### PR TITLE
feat: add mac desktop download page and release automation

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -1,0 +1,70 @@
+name: Desktop Release (macOS)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-macos:
+    name: Build and publish macOS desktop artifacts
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Sync Tauri version with package version
+        run: node scripts/sync-tauri-version.mjs
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build macOS desktop bundles
+        shell: bash
+        run: |
+          set -euo pipefail
+          yarn desktop:build -- --bundles app,dmg
+
+      - name: Prepare stable release asset names
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+
+          arm_dmg="$(find src-tauri/target/release/bundle -type f -name '*aarch64*.dmg' | head -n 1)"
+          intel_dmg="$(find src-tauri/target/release/bundle -type f -name '*x64*.dmg' | head -n 1)"
+
+          if [[ -z "$arm_dmg" || -z "$intel_dmg" ]]; then
+            echo "Expected both arm64 and x64 macOS DMG artifacts, but at least one is missing."
+            find src-tauri/target/release/bundle -type f || true
+            exit 1
+          fi
+
+          cp "$arm_dmg" release-assets/Phonograph-macOS-Apple-Silicon.dmg
+          cp "$intel_dmg" release-assets/Phonograph-macOS-Intel.dmg
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-assets/Phonograph-macOS-Apple-Silicon.dmg
+            release-assets/Phonograph-macOS-Intel.dmg
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Build desktop bundles:
 yarn desktop:build
 ```
 
+### Desktop release + download links
+
+- Pushing a semver tag (for example `v1.3.24`) triggers `.github/workflows/desktop-release-macos.yml`.
+- The workflow publishes two stable assets to the GitHub release:
+  - `Phonograph-macOS-Apple-Silicon.dmg`
+  - `Phonograph-macOS-Intel.dmg`
+- The app exposes an in-product download screen at `/download` and a shortcut from **Settings → Desktop App**.
+
 ## Build and Preview
 
 ```bash

--- a/plans/2026-03-12-duo-25-desktop-release-download-page-plan.md
+++ b/plans/2026-03-12-duo-25-desktop-release-download-page-plan.md
@@ -1,0 +1,24 @@
+# DUO-25 — Desktop Release + macOS Download Page
+
+## Objective
+Ship a user-facing download page for macOS binaries and automate release publishing so links stay stable.
+
+## Scope
+1. Add an in-app `/download` route with direct links for:
+   - Apple Silicon macOS DMG
+   - Intel macOS DMG
+2. Add a discoverable entrypoint from Settings.
+3. Add CI workflow to build macOS artifacts on semver tags and publish stable asset names.
+4. Keep Tauri desktop version aligned with `package.json`.
+
+## Deliverables
+- UI route and localized text for desktop downloads.
+- Settings card linking users to the download page.
+- GitHub Actions release workflow for macOS bundles.
+- Version sync utility + bump script update.
+- README update describing release flow and download surface.
+
+## Validation
+- Typecheck and test suite pass.
+- Linting passes.
+- New workflow is syntactically valid.

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -55,3 +55,14 @@ if (fs.existsSync(lockPath)) {
 }
 
 process.stdout.write(next);
+
+const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+if (fs.existsSync(tauriConfigPath)) {
+  try {
+    const tauriConfig = readJson(tauriConfigPath);
+    tauriConfig.version = next;
+    fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
+  } catch (e) {
+    // Ignore tauri config updates if the file is malformed.
+  }
+}

--- a/scripts/sync-tauri-version.mjs
+++ b/scripts/sync-tauri-version.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const packageJsonPath = path.join(repoRoot, "package.json");
+const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+
+if (!fs.existsSync(packageJsonPath) || !fs.existsSync(tauriConfigPath)) {
+  process.exit(0);
+}
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, "utf8"));
+
+if (!packageJson.version || typeof packageJson.version !== "string") {
+  throw new Error("package.json version is missing or invalid");
+}
+
+tauriConfig.version = packageJson.version;
+fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
+
+process.stdout.write(packageJson.version);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phonograph",
-  "version": "1.3.18",
+  "version": "1.3.23",
   "identifier": "app.phonograph.desktop",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   PODCASTVIEW,
   DISCOVERVIEW,
   SETTINGSVIEW,
+  DOWNLOADVIEW,
 } from "./constants";
 import playerFunctions from "./engine/player";
 import { getPodcastEngine, checkIfNewPodcastInURL } from "./engine";
@@ -34,6 +35,7 @@ const Playlist = React.lazy(async () => await import("./core/Playlist"));
 const MediaControl = React.lazy(async () => await import("./core/MediaControl"));
 const PodcastView = React.lazy(async () => await import("./podcast/PodcastView"));
 const Footer = React.lazy(async () => await import("./core/Footer"));
+const DesktopDownload = React.lazy(async () => await import("./core/DesktopDownload"));
 
 const Loading = () => (
   <div style={{ margin: "0 auto", display: "block", paddingTop: "40%", textAlign: "center" }}>
@@ -181,6 +183,16 @@ const App: React.FC = () => {
             render={() => (
               <Suspense fallback={<Loading />}>
                 <Settings />
+              </Suspense>
+            )}
+          />
+
+          <Route
+            path={[DOWNLOADVIEW, `${DOWNLOADVIEW}/mac`]}
+            exact
+            render={() => (
+              <Suspense fallback={<Loading />}>
+                <DesktopDownload />
               </Suspense>
             )}
           />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const PODCASTVIEW = "/podcast" as const;
 export const DISCOVERVIEW = "/discover" as const;
 export const SETTINGSVIEW = "/settings" as const;
 export const PLAYLIST = "/playlist" as const;
+export const DOWNLOADVIEW = "/download" as const;
 
 export type RoutePath =
   | typeof ROOT
@@ -12,4 +13,5 @@ export type RoutePath =
   | typeof PODCASTVIEW
   | typeof DISCOVERVIEW
   | typeof SETTINGSVIEW
-  | typeof PLAYLIST;
+  | typeof PLAYLIST
+  | typeof DOWNLOADVIEW;

--- a/src/core/DesktopDownload.tsx
+++ b/src/core/DesktopDownload.tsx
@@ -1,0 +1,83 @@
+import AppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import React from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import { FormattedMessage, useIntl } from "react-intl";
+
+const RELEASES_LATEST_URL = "https://github.com/navio/phonograph/releases/latest";
+const MAC_APPLE_SILICON_URL = `${RELEASES_LATEST_URL}/download/Phonograph-macOS-Apple-Silicon.dmg`;
+const MAC_INTEL_URL = `${RELEASES_LATEST_URL}/download/Phonograph-macOS-Intel.dmg`;
+
+const DesktopDownload: React.FC = () => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <AppBar sx={{ WebkitAppRegion: "drag" }} position="static">
+        <Toolbar variant="dense">
+          <Typography variant="h6">
+            <FormattedMessage id="download.title" defaultMessage="Download Desktop App" />
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            <FormattedMessage
+              id="download.description"
+              defaultMessage="Choose your Mac chip architecture to download the latest Phonograph desktop build."
+            />
+          </Typography>
+
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5}>
+            <Button
+              variant="contained"
+              color="primary"
+              component="a"
+              href={MAC_APPLE_SILICON_URL}
+              rel="noopener noreferrer"
+            >
+              <FormattedMessage id="download.appleSilicon" defaultMessage="Download for Apple Silicon" />
+            </Button>
+
+            <Button
+              variant="contained"
+              color="primary"
+              component="a"
+              href={MAC_INTEL_URL}
+              rel="noopener noreferrer"
+            >
+              <FormattedMessage id="download.intel" defaultMessage="Download for Intel Mac" />
+            </Button>
+
+            <Button
+              variant="outlined"
+              color="primary"
+              component="a"
+              href={RELEASES_LATEST_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={intl.formatMessage({ id: "a11y.openDesktopDownloads", defaultMessage: "Open desktop downloads" })}
+            >
+              <FormattedMessage id="download.releaseNotes" defaultMessage="View Release Notes" />
+            </Button>
+          </Stack>
+
+          <Typography variant="caption" sx={{ mt: 2, display: "block" }}>
+            <FormattedMessage
+              id="download.warning"
+              defaultMessage="If macOS warns that the app is from an unidentified developer, right-click the app and choose Open once to trust it."
+            />
+          </Typography>
+        </CardContent>
+      </Card>
+    </>
+  );
+};
+
+export default DesktopDownload;

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -82,7 +82,17 @@
   "podcastSettings.skipEnd": "Skip End",
   "podcastSettings.defaultSpeed": "Default Speed",
   "a11y.openUserManual": "Open user manual",
+  "a11y.openDesktopDownloads": "Open desktop downloads",
+  "download.title": "Download Desktop App",
+  "download.description": "Choose your Mac chip architecture to download the latest Phonograph desktop build.",
+  "download.appleSilicon": "Download for Apple Silicon",
+  "download.intel": "Download for Intel Mac",
+  "download.releaseNotes": "View Release Notes",
+  "download.warning": "If macOS warns that the app is from an unidentified developer, right-click the app and choose Open once to trust it.",
   "settings.userManual": "User Manual",
   "settings.userManualDescription": "Read the official Phonograph docs for onboarding, playback controls, and troubleshooting.",
-  "settings.openUserManual": "Open User Manual"
+  "settings.openUserManual": "Open User Manual",
+  "settings.desktopApp": "Desktop App",
+  "settings.desktopAppDescription": "Need the macOS app? Open the download page for Apple Silicon and Intel builds.",
+  "settings.openDesktopDownloads": "Open Desktop Downloads"
 }

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -82,7 +82,17 @@
   "podcastSettings.skipEnd": "Saltar final",
   "podcastSettings.defaultSpeed": "Velocidad predeterminada",
   "a11y.openUserManual": "Abrir manual de usuario",
+  "a11y.openDesktopDownloads": "Abrir descargas de escritorio",
+  "download.title": "Descargar aplicación de escritorio",
+  "download.description": "Elige la arquitectura de tu Mac para descargar la última versión de escritorio de Phonograph.",
+  "download.appleSilicon": "Descargar para Apple Silicon",
+  "download.intel": "Descargar para Mac Intel",
+  "download.releaseNotes": "Ver notas de versión",
+  "download.warning": "Si macOS avisa que la app es de un desarrollador no identificado, haz clic derecho en la app y elige Abrir una vez para confiar en ella.",
   "settings.userManual": "Manual de usuario",
   "settings.userManualDescription": "Consulta la documentación oficial de Phonograph para introducción, controles de reproducción y solución de problemas.",
-  "settings.openUserManual": "Abrir manual de usuario"
+  "settings.openUserManual": "Abrir manual de usuario",
+  "settings.desktopApp": "Aplicación de escritorio",
+  "settings.desktopAppDescription": "¿Necesitas la app para macOS? Abre la página de descargas para Apple Silicon e Intel.",
+  "settings.openDesktopDownloads": "Abrir descargas de escritorio"
 }

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -82,7 +82,17 @@
   "podcastSettings.skipEnd": "Sauter la fin",
   "podcastSettings.defaultSpeed": "Vitesse par défaut",
   "a11y.openUserManual": "Ouvrir le manuel utilisateur",
+  "a11y.openDesktopDownloads": "Ouvrir les téléchargements desktop",
+  "download.title": "Télécharger l'application desktop",
+  "download.description": "Choisissez l'architecture de votre Mac pour télécharger la dernière version desktop de Phonograph.",
+  "download.appleSilicon": "Télécharger pour Apple Silicon",
+  "download.intel": "Télécharger pour Mac Intel",
+  "download.releaseNotes": "Voir les notes de version",
+  "download.warning": "Si macOS indique que l'app vient d'un développeur non identifié, faites un clic droit sur l'app puis Ouvrir une fois pour l'autoriser.",
   "settings.userManual": "Manuel utilisateur",
   "settings.userManualDescription": "Consultez la documentation officielle de Phonograph pour la prise en main, les contrôles de lecture et le dépannage.",
-  "settings.openUserManual": "Ouvrir le manuel utilisateur"
+  "settings.openUserManual": "Ouvrir le manuel utilisateur",
+  "settings.desktopApp": "Application desktop",
+  "settings.desktopAppDescription": "Besoin de l'app macOS ? Ouvrez la page de téléchargement pour les builds Apple Silicon et Intel.",
+  "settings.openDesktopDownloads": "Ouvrir les téléchargements desktop"
 }

--- a/src/i18n/translations/zh.json
+++ b/src/i18n/translations/zh.json
@@ -82,7 +82,17 @@
   "podcastSettings.skipEnd": "跳过结尾",
   "podcastSettings.defaultSpeed": "默认速度",
   "a11y.openUserManual": "打开用户手册",
+  "a11y.openDesktopDownloads": "打开桌面版下载",
+  "download.title": "下载桌面版应用",
+  "download.description": "请选择你的 Mac 芯片架构以下载最新的 Phonograph 桌面版。",
+  "download.appleSilicon": "下载 Apple Silicon 版本",
+  "download.intel": "下载 Intel Mac 版本",
+  "download.releaseNotes": "查看发布说明",
+  "download.warning": "如果 macOS 提示应用来自未识别开发者，请右键应用并选择“打开”一次以信任该应用。",
   "settings.userManual": "用户手册",
   "settings.userManualDescription": "阅读 Phonograph 官方文档，了解上手指南、播放控制和故障排查。",
-  "settings.openUserManual": "打开用户手册"
+  "settings.openUserManual": "打开用户手册",
+  "settings.desktopApp": "桌面版应用",
+  "settings.desktopAppDescription": "需要 macOS 应用吗？打开下载页面获取 Apple Silicon 和 Intel 版本。",
+  "settings.openDesktopDownloads": "打开桌面版下载"
 }

--- a/src/podcast/Settings.tsx
+++ b/src/podcast/Settings.tsx
@@ -18,6 +18,7 @@ import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
 import LinearProgress from "@mui/material/LinearProgress";
 import { FormattedMessage, useIntl } from "react-intl";
+import { useHistory } from "react-router-dom";
 
 import { Button } from "@mui/material";
 import PodcastEngine from "podcastsuite";
@@ -37,6 +38,7 @@ import { initializeLibrary } from "../engine";
 import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
 import { buildOpml, parseOpml } from "./opml";
 import { importFeeds } from "./opmlImporter";
+import { DOWNLOADVIEW } from "../constants";
 
 import Switch from "@mui/material/Switch";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -52,6 +54,7 @@ const USER_MANUAL_URL = "https://phonograph.app/docs/";
 const Settings: React.FC = () => {
   const { state, dispatch, engine } = useContext(AppContext) as AppContextValue;
   const intl = useIntl();
+  const history = useHistory();
 
   const [notice, setNotice] = useState<{ open: boolean; message: string; severity: "success" | "info" | "warning" | "error" }>(
     {
@@ -439,6 +442,28 @@ const Settings: React.FC = () => {
             aria-label={intl.formatMessage({ id: "a11y.openUserManual", defaultMessage: "Open user manual" })}
           >
             <FormattedMessage id="settings.openUserManual" defaultMessage="Open User Manual" />
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            <FormattedMessage id="settings.desktopApp" defaultMessage="Desktop App" />
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 1.5 }}>
+            <FormattedMessage
+              id="settings.desktopAppDescription"
+              defaultMessage="Need the macOS app? Open the download page for Apple Silicon and Intel builds."
+            />
+          </Typography>
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={() => history.push(DOWNLOADVIEW)}
+            aria-label={intl.formatMessage({ id: "a11y.openDesktopDownloads", defaultMessage: "Open desktop downloads" })}
+          >
+            <FormattedMessage id="settings.openDesktopDownloads" defaultMessage="Open Desktop Downloads" />
           </Button>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Context
Implements DUO-25: add a user-facing desktop download link for macOS and orchestrate release publication for desktop artifacts.

## What Changed
- Added in-app download route at `/download` with direct links for Apple Silicon + Intel macOS DMGs.
- Added **Settings → Desktop App** card to surface the download page from the app UI.
- Added localized strings for English, Spanish, French, and Chinese.
- Added `.github/workflows/desktop-release-macos.yml` to build macOS desktop bundles on semver tags and publish stable release asset names:
  - `Phonograph-macOS-Apple-Silicon.dmg`
  - `Phonograph-macOS-Intel.dmg`
- Added `scripts/sync-tauri-version.mjs` and updated `scripts/bump-version.mjs` to keep `src-tauri/tauri.conf.json` version synced to `package.json`.
- Updated README and added delivery plan doc at `plans/2026-03-12-duo-25-desktop-release-download-page-plan.md`.

## Validation
- `yarn install --frozen-lockfile`
- `yarn typecheck`
- `yarn lint:errors`
- `yarn test`

## Rollout Notes
- Release workflow triggers on tag pushes matching `v*.*.*`.
- After the next release tag, `/download` links resolve to the latest published macOS artifacts via GitHub Releases.
