### PR TITLE
feat(ci): unify web and desktop CI/release pipelines

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,4 +1,4 @@
-name: Quality Gates
+name: Unified CI
 
 on:
   pull_request:
@@ -9,13 +9,40 @@ permissions:
   contents: read
 
 concurrency:
-  group: quality-gates-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  web-quality:
-    name: Web lint/test/build
+  detect_platforms:
+    name: Detect Targets
     runs-on: ubuntu-latest
+    outputs:
+      desktop_enabled: ${{ steps.detect.outputs.desktop_enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect desktop workspace
+        id: detect
+        run: |
+          if [ -f src-tauri/tauri.conf.json ]; then
+            echo "desktop_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "desktop_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report target matrix
+        run: |
+          {
+            echo "## Unified CI target detection"
+            echo "- Desktop enabled: ${{ steps.detect.outputs.desktop_enabled }}"
+            echo "- Web enabled: true"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  web_quality:
+    name: Web Quality
+    runs-on: ubuntu-latest
+    needs: detect_platforms
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,208 +57,177 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Typecheck
+        id: typecheck
         run: yarn typecheck
 
       - name: Lint
+        id: lint
         run: yarn lint:errors
 
-      - name: Test
+      - name: Unit tests
+        id: tests
         run: yarn test
 
-      - name: Build web bundle
+      - name: Build web distribution
+        id: build
         run: yarn bundle
 
-  desktop-compile:
-    name: Desktop compile smoke
-    runs-on: ubuntu-latest
-    outputs:
-      has_desktop: ${{ steps.detect.outputs.has_desktop }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Detect desktop workspace
-        id: detect
-        shell: bash
-        run: |
-          if [[ -f src-tauri/Cargo.toml && -f src-tauri/tauri.conf.json ]]; then
-            echo "has_desktop=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_desktop=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Setup Node
-        if: steps.detect.outputs.has_desktop == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-
-      - name: Install desktop dependencies
-        if: steps.detect.outputs.has_desktop == 'true'
-        run: yarn install --frozen-lockfile
-
-      - name: Install desktop Linux system dependencies
-        if: steps.detect.outputs.has_desktop == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf
-
-          if apt-cache show libwebkit2gtk-4.1-dev >/dev/null 2>&1; then
-            sudo apt-get install -y libwebkit2gtk-4.1-dev
-          else
-            sudo apt-get install -y libwebkit2gtk-4.0-dev
-          fi
-
-      - name: Setup Rust
-        if: steps.detect.outputs.has_desktop == 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Compile desktop app
-        if: steps.detect.outputs.has_desktop == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts['desktop:build'] ? 0 : 1);"; then
-            yarn desktop:build -- --no-bundle
-          else
-            cargo check --manifest-path src-tauri/Cargo.toml --locked
-          fi
-
-      - name: Desktop compile summary
-        if: steps.detect.outputs.has_desktop != 'true'
-        run: echo "No src-tauri workspace found; skipping desktop compile smoke."
-
-  desktop-package-smoke:
-    name: Desktop package smoke + artifacts
-    runs-on: ubuntu-latest
-    needs: desktop-compile
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        if: needs.desktop-compile.outputs.has_desktop == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-
-      - name: Install desktop dependencies
-        if: needs.desktop-compile.outputs.has_desktop == 'true'
-        run: yarn install --frozen-lockfile
-
-      - name: Install desktop Linux system dependencies
-        if: needs.desktop-compile.outputs.has_desktop == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf
-
-          if apt-cache show libwebkit2gtk-4.1-dev >/dev/null 2>&1; then
-            sudo apt-get install -y libwebkit2gtk-4.1-dev
-          else
-            sudo apt-get install -y libwebkit2gtk-4.0-dev
-          fi
-
-      - name: Setup Rust
-        if: needs.desktop-compile.outputs.has_desktop == 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Package unsigned desktop build
-        if: needs.desktop-compile.outputs.has_desktop == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts['desktop:build'] ? 0 : 1);"; then
-            yarn desktop:build -- --bundles deb,appimage
-          else
-            cargo build --manifest-path src-tauri/Cargo.toml --release --locked
-          fi
-
-      - name: Collect desktop artifacts
-        id: collect
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p desktop-artifacts
-          if [[ "${{ needs.desktop-compile.outputs.has_desktop }}" == "true" ]]; then
-            if [[ -d src-tauri/target/release/bundle ]]; then
-              cp -R src-tauri/target/release/bundle desktop-artifacts/
-            fi
-
-            if [[ -f src-tauri/target/release/phonograph ]]; then
-              cp src-tauri/target/release/phonograph desktop-artifacts/
-            fi
-
-            if [[ -f src-tauri/target/release/phonograph.exe ]]; then
-              cp src-tauri/target/release/phonograph.exe desktop-artifacts/
-            fi
-
-            {
-              echo "run_id=${GITHUB_RUN_ID}"
-              echo "sha=${GITHUB_SHA}"
-              echo "unsigned=true"
-            } > desktop-artifacts/metadata.txt
-          else
-            {
-              echo "Desktop package smoke skipped."
-              echo "Reason: src-tauri workspace not found in this branch."
-              echo "run_id=${GITHUB_RUN_ID}"
-              echo "sha=${GITHUB_SHA}"
-            } > desktop-artifacts/desktop-smoke-skipped.txt
-          fi
-
-          artifact_count=$(find desktop-artifacts -type f | wc -l | tr -d ' ')
-          echo "artifact_count=$artifact_count" >> "$GITHUB_OUTPUT"
-
-      - name: Upload desktop artifacts
+      - name: Upload web build artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-unsigned-${{ github.run_id }}
-          path: desktop-artifacts
+          name: web-dist
+          path: dist
           if-no-files-found: error
 
-      - name: Ensure desktop artifacts were produced
-        if: needs.desktop-compile.outputs.has_desktop == 'true'
-        shell: bash
+      - name: Report web quality status
+        if: always()
         run: |
-          if [[ "${{ steps.collect.outputs.artifact_count }}" -lt 2 ]]; then
-            echo "Expected desktop binaries/packages plus metadata for QA review."
-            exit 1
+          {
+            echo "## Web quality"
+            echo "- Typecheck: ${{ steps.typecheck.outcome }}"
+            echo "- Lint: ${{ steps.lint.outcome }}"
+            echo "- Unit tests: ${{ steps.tests.outcome }}"
+            echo "- Build: ${{ steps.build.outcome }}"
+            echo "- Job result: ${{ job.status }}"
+            echo "- Dist artifact uploaded for downstream inspection."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  web_coverage:
+    name: Web Coverage Gate
+    runs-on: ubuntu-latest
+    needs: web_quality
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests with coverage
+        id: coverage
+        run: yarn test:coverage
+
+      - name: Enforce changed-file coverage threshold
+        id: coverage_gate
+        env:
+          COVERAGE_BASE_REF: origin/${{ github.base_ref }}
+          COVERAGE_THRESHOLD: "70"
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          yarn coverage:changed
+
+      - name: Report coverage status
+        if: always()
+        run: |
+          {
+            echo "## Web coverage"
+            echo "- Coverage run: ${{ steps.coverage.outcome }}"
+            echo "- Changed-file gate: ${{ steps.coverage_gate.outcome }}"
+            echo "- Job result: ${{ job.status }}"
+            echo "- Gate threshold: 70%."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  desktop_quality:
+    name: Desktop Quality (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: detect_platforms
+    if: needs.detect_platforms.outputs.desktop_enabled == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+          if apt-cache show libwebkit2gtk-4.1-dev >/dev/null 2>&1; then
+            sudo apt-get install -y libwebkit2gtk-4.1-dev
+          else
+            sudo apt-get install -y libwebkit2gtk-4.0-dev
           fi
 
-  merge-gate:
-    name: Merge gate (web + desktop)
-    runs-on: ubuntu-latest
-    needs:
-      - web-quality
-      - desktop-compile
-      - desktop-package-smoke
-    if: always()
-    steps:
-      - name: Enforce required CI outcomes
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Validate desktop build
+        id: desktop_build
+        run: cargo check --manifest-path src-tauri/Cargo.toml --locked
+
+      - name: Report desktop status
+        if: always()
         shell: bash
         run: |
-          set -euo pipefail
+          {
+            echo "## Desktop quality (${{ matrix.os }})"
+            echo "- Rust compile check: ${{ steps.desktop_build.outcome }}"
+            echo "- Job result: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          web_result="${{ needs.web-quality.result }}"
-          compile_result="${{ needs.desktop-compile.result }}"
-          package_result="${{ needs.desktop-package-smoke.result }}"
+  ci_status:
+    name: CI Status Summary
+    runs-on: ubuntu-latest
+    needs: [detect_platforms, web_quality, web_coverage, desktop_quality]
+    if: always()
+    steps:
+      - name: Summarize pipeline outcome
+        run: |
+          web_quality="${{ needs.web_quality.result }}"
+          web_coverage="${{ needs.web_coverage.result }}"
+          desktop_quality="${{ needs.desktop_quality.result }}"
 
-          echo "web-quality: $web_result"
-          echo "desktop-compile: $compile_result"
-          echo "desktop-package-smoke: $package_result"
+          {
+            echo "## Unified CI status"
+            echo "| Stage | Result |"
+            echo "| --- | --- |"
+            echo "| Web quality | ${web_quality} |"
+            echo "| Web coverage | ${web_coverage} |"
+            echo "| Desktop quality | ${desktop_quality} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$web_result" != "success" || "$compile_result" != "success" || "$package_result" != "success" ]]; then
-            echo "Merge blocked: web or desktop quality checks failed."
+          failed=0
+          if [ "$web_quality" != "success" ]; then
+            failed=1
+          fi
+
+          if [ "$web_coverage" != "success" ] && [ "$web_coverage" != "skipped" ]; then
+            failed=1
+          fi
+
+          if [ "$desktop_quality" != "success" ] && [ "$desktop_quality" != "skipped" ]; then
+            failed=1
+          fi
+
+          if [ "$failed" -ne 0 ]; then
+            echo "Unified CI pipeline reported one or more failures."
             exit 1
           fi

--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -1,0 +1,238 @@
+name: Unified Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  detect_platforms:
+    name: Detect Release Targets
+    runs-on: ubuntu-latest
+    outputs:
+      desktop_enabled: ${{ steps.detect.outputs.desktop_enabled }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect desktop workspace
+        id: detect
+        run: |
+          if [ -f src-tauri/tauri.conf.json ]; then
+            echo "desktop_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "desktop_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report release targets
+        run: |
+          {
+            echo "## Unified release target detection"
+            echo "- Web release: enabled"
+            echo "- Desktop release: ${{ steps.detect.outputs.desktop_enabled }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  web_release:
+    name: Web Release Artifact
+    runs-on: ubuntu-latest
+    needs: detect_platforms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Validate release environment
+        env:
+          LISTEN_NOTES_API_KEY: ${{ secrets.LISTEN_NOTES_API_KEY }}
+          LISTENNOTES: ${{ secrets.LISTENNOTES }}
+        run: |
+          if [ -z "${LISTEN_NOTES_API_KEY:-}" ] && [ -z "${LISTENNOTES:-}" ]; then
+            echo "Missing release secret: set LISTEN_NOTES_API_KEY (preferred) or LISTENNOTES."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build web distribution
+        id: web_build
+        env:
+          LISTENNOTES: ${{ secrets.LISTEN_NOTES_API_KEY || secrets.LISTENNOTES }}
+        run: yarn build
+
+      - name: Archive web distribution
+        id: web_archive
+        run: |
+          archive="phonograph-web-${GITHUB_REF_NAME}.tar.gz"
+          tar -czf "$archive" dist
+          echo "WEB_RELEASE_ARCHIVE=$archive" >> "$GITHUB_ENV"
+
+      - name: Publish web release artifact
+        id: web_publish
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Phonograph Release ${{ github.ref_name }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+          files: ${{ env.WEB_RELEASE_ARCHIVE }}
+
+      - name: Report web release status
+        if: always()
+        run: |
+          {
+            echo "## Web release"
+            echo "- Build: ${{ steps.web_build.outcome }}"
+            echo "- Archive: ${{ steps.web_archive.outcome }}"
+            echo "- Publish release asset: ${{ steps.web_publish.outcome }}"
+            echo "- Job result: ${{ job.status }}"
+            if [ -n "${WEB_RELEASE_ARCHIVE:-}" ]; then
+              echo "- Release asset: ${WEB_RELEASE_ARCHIVE}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  desktop_release:
+    name: Desktop Release (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [detect_platforms, web_release]
+    if: needs.detect_platforms.outputs.desktop_enabled == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+          if apt-cache show libwebkit2gtk-4.1-dev >/dev/null 2>&1; then
+            sudo apt-get install -y libwebkit2gtk-4.1-dev
+          else
+            sudo apt-get install -y libwebkit2gtk-4.0-dev
+          fi
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Prepare Apple API key
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        env:
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          if [ -z "$APPLE_API_PRIVATE_KEY" ] || [ -z "$APPLE_API_KEY" ]; then
+            echo "APPLE_API_PRIVATE_KEY and APPLE_API_KEY secrets are required for macOS signing"
+            exit 1
+          fi
+
+          key_file="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          echo "$APPLE_API_PRIVATE_KEY" > "$key_file"
+          echo "APPLE_API_KEY_PATH=$key_file" >> "$GITHUB_ENV"
+
+      - name: Validate desktop signing configuration
+        id: desktop_signing
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+          TAURI_WINDOWS_CERTIFICATE: ${{ secrets.TAURI_WINDOWS_CERTIFICATE }}
+          TAURI_WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.TAURI_WINDOWS_CERTIFICATE_PASSWORD }}
+        run: node scripts/validate-desktop-signing-env.mjs --force
+
+      - name: Build and publish signed desktop bundles
+        id: desktop_build_publish
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+          TAURI_WINDOWS_CERTIFICATE: ${{ secrets.TAURI_WINDOWS_CERTIFICATE }}
+          TAURI_WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.TAURI_WINDOWS_CERTIFICATE_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: Phonograph Release ${{ github.ref_name }}
+          releaseBody: Automated web and desktop release artifacts for ${{ github.ref_name }}.
+          releaseDraft: true
+          prerelease: false
+          includeDebug: false
+          tauriScript: yarn desktop:build:ci
+
+      - name: Report desktop release status
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Desktop release (${{ matrix.os }})"
+            echo "- Signing validation: ${{ steps.desktop_signing.outcome }}"
+            echo "- Build + publish: ${{ steps.desktop_build_publish.outcome }}"
+            echo "- Job result: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release_status:
+    name: Release Status Summary
+    runs-on: ubuntu-latest
+    needs: [detect_platforms, web_release, desktop_release]
+    if: always()
+    steps:
+      - name: Summarize release outcome
+        run: |
+          web_release="${{ needs.web_release.result }}"
+          desktop_release="${{ needs.desktop_release.result }}"
+
+          {
+            echo "## Unified release status"
+            echo "| Stage | Result |"
+            echo "| --- | --- |"
+            echo "| Web release | ${web_release} |"
+            echo "| Desktop release | ${desktop_release} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$web_release" != "success" ]; then
+            echo "Web release failed."
+            exit 1
+          fi
+
+          if [ "$desktop_release" != "success" ] && [ "$desktop_release" != "skipped" ]; then
+            echo "Desktop release failed."
+            exit 1
+          fi

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -42,7 +42,16 @@ jobs:
           next="$(node -p "require('./package.json').version")"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json || true
+          git add package.json package-lock.json
+
+          if [ -f src-tauri/tauri.conf.json ]; then
+            git add src-tauri/tauri.conf.json
+          fi
+
+          if [ -f src-tauri/Cargo.toml ]; then
+            git add src-tauri/Cargo.toml
+          fi
+
           if git diff --cached --quiet; then
             echo "No version changes to commit."
             exit 0
@@ -51,3 +60,16 @@ jobs:
           git tag "v$next"
           git push
           git push --tags
+
+      - name: Report version bump status
+        if: always()
+        run: |
+          {
+            echo "## Version bump"
+            echo "- Release bump skipped: ${{ steps.check.outputs.skip }}"
+            if [ "${{ steps.check.outputs.skip }}" = "true" ]; then
+              echo "- Existing release commit detected; no new tag created."
+            else
+              echo "- Patch version bumped and tag pushed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -223,17 +223,34 @@ Run the local quality gate sequence with:
 yarn quality
 ```
 
-PR CI now enforces a dual-surface quality matrix:
+PR CI now runs a unified web + desktop quality pipeline:
 
-- `web-quality`: typecheck, lint, test, and production web bundle build.
-- `desktop-compile`: desktop compile smoke validation when `src-tauri/` is present.
-- `desktop-package-smoke`: unsigned desktop package smoke build and artifact upload for QA.
-- `merge-gate`: fails when any required web/desktop check fails.
-
-Desktop smoke artifacts are published as `desktop-unsigned-<run_id>` in the Actions run.
+- `web_quality`: typecheck, lint, tests, and web build artifact upload.
+- `web_coverage`: changed-file coverage gate for pull requests.
+- `desktop_quality`: cross-platform desktop compile checks when `src-tauri/` is present.
+- `ci_status`: consolidated pass/fail summary across web and desktop stages.
 
 Framework and linting standards are documented in `docs/framework-best-practices.md`.
 Current repository includes targeted tests for reducers, engine events, app store behavior, and podcast utilities.
+
+## CI and Release Automation
+
+- Unified CI workflow: `.github/workflows/quality-gates.yml`
+  - Runs web typecheck, lint, tests, build artifact upload, and PR coverage gate.
+  - Detects desktop workspace automatically and runs desktop compile checks on Linux/macOS/Windows when available.
+  - Publishes a final `CI Status Summary` job with stage-by-stage results.
+- Unified release workflow: `.github/workflows/unified-release.yml`
+  - Triggers on version tags (`v*`).
+  - Builds and uploads a web release archive (`phonograph-web-<tag>.tar.gz`) to a draft GitHub release.
+  - Builds and publishes signed desktop bundles (when `src-tauri` exists) with per-OS status summaries.
+- Version bump workflow: `.github/workflows/version-bump.yml`
+  - Bumps patch version on `main`/`master`, tags, pushes, and keeps desktop versions in sync when present.
+
+### Release Secrets
+
+- Web release: `LISTEN_NOTES_API_KEY` (preferred) or `LISTENNOTES`.
+- macOS desktop signing/notarization: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_PRIVATE_KEY`.
+- Windows desktop signing: `TAURI_WINDOWS_CERTIFICATE`, `TAURI_WINDOWS_CERTIFICATE_PASSWORD`.
 
 ## Roadmap Direction
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "scripts": {
     "start": "vite",
     "desktop:dev": "tauri dev",
-    "desktop:build": "tauri build",
+    "desktop:sync-version": "node scripts/sync-desktop-version.mjs",
+    "desktop:build": "yarn desktop:sync-version && tauri build",
+    "desktop:build:ci": "yarn desktop:sync-version && node scripts/validate-desktop-signing-env.mjs --force && tauri build",
     "build": "yarn getter && vite build && yarn SEO && yarn sw && yarn docs:manuals:build && yarn lambda:build",
     "serve": "vite preview",
     "docs:manuals:dev": "vitepress dev manuals",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -32,6 +32,28 @@ const bump = (version, type) => {
   return `${major}.${minor}.${patch + 1}`;
 };
 
+const syncDesktopVersion = (version) => {
+  const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+  const cargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
+
+  if (!fs.existsSync(tauriConfigPath) || !fs.existsSync(cargoTomlPath)) {
+    return;
+  }
+
+  const tauriConfig = readJson(tauriConfigPath);
+  if (tauriConfig.version !== version) {
+    tauriConfig.version = version;
+    writeJson(tauriConfigPath, tauriConfig);
+  }
+
+  const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
+  const updatedCargoToml = cargoToml.replace(/^(version\s*=\s*").*(")$/m, `$1${version}$2`);
+
+  if (updatedCargoToml !== cargoToml) {
+    fs.writeFileSync(cargoTomlPath, updatedCargoToml);
+  }
+};
+
 const pkgPath = path.join(repoRoot, "package.json");
 const pkg = readJson(pkgPath);
 const current = pkg.version;
@@ -53,5 +75,7 @@ if (fs.existsSync(lockPath)) {
     // Ignore lockfile updates if it's malformed/out of date.
   }
 }
+
+syncDesktopVersion(next);
 
 process.stdout.write(next);

--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const packageJsonPath = path.join(root, "package.json");
+const tauriConfigPath = path.join(root, "src-tauri", "tauri.conf.json");
+const cargoTomlPath = path.join(root, "src-tauri", "Cargo.toml");
+
+if (!fs.existsSync(tauriConfigPath) || !fs.existsSync(cargoTomlPath)) {
+  process.stdout.write("Desktop workspace not found, skipping version sync.\n");
+  process.exit(0);
+}
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const version = packageJson.version;
+
+if (!version || typeof version !== "string") {
+  throw new Error("package.json version is missing or invalid");
+}
+
+const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, "utf8"));
+if (tauriConfig.version !== version) {
+  tauriConfig.version = version;
+  fs.writeFileSync(tauriConfigPath, `${JSON.stringify(tauriConfig, null, 2)}\n`);
+}
+
+const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
+const updatedCargoToml = cargoToml.replace(/^(version\s*=\s*").*(")$/m, `$1${version}$2`);
+
+if (updatedCargoToml !== cargoToml) {
+  fs.writeFileSync(cargoTomlPath, updatedCargoToml);
+}
+
+process.stdout.write(`Desktop version synchronized to ${version}\n`);

--- a/scripts/validate-desktop-signing-env.mjs
+++ b/scripts/validate-desktop-signing-env.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const hasDesktopConfig = fs.existsSync(path.join(root, "src-tauri", "tauri.conf.json"));
+
+if (!hasDesktopConfig) {
+  process.stdout.write("Desktop workspace not found, skipping signing validation.\n");
+  process.exit(0);
+}
+
+const isCi = process.env.CI === "true";
+const isReleaseRef = process.env.GITHUB_REF_TYPE === "tag";
+const shouldEnforce = process.argv.includes("--force") || (isCi && isReleaseRef);
+
+if (!shouldEnforce) {
+  process.stdout.write("Skipping desktop signing environment validation.\n");
+  process.exit(0);
+}
+
+const missing = [];
+
+const requireEnv = (name) => {
+  if (!process.env[name]) {
+    missing.push(name);
+  }
+};
+
+const platform = process.platform;
+if (platform === "darwin") {
+  requireEnv("APPLE_CERTIFICATE");
+  requireEnv("APPLE_CERTIFICATE_PASSWORD");
+  requireEnv("APPLE_SIGNING_IDENTITY");
+  requireEnv("APPLE_API_ISSUER");
+  requireEnv("APPLE_API_KEY");
+  requireEnv("APPLE_API_KEY_PATH");
+}
+
+if (platform === "win32") {
+  requireEnv("TAURI_WINDOWS_CERTIFICATE");
+  requireEnv("TAURI_WINDOWS_CERTIFICATE_PASSWORD");
+}
+
+if (missing.length > 0) {
+  console.error("Missing required desktop signing environment variables:");
+  for (const variableName of missing) {
+    console.error(`- ${variableName}`);
+  }
+  process.exit(1);
+}
+
+process.stdout.write("Desktop signing environment validation passed.\n");


### PR DESCRIPTION
## Summary
- replace the existing quality workflow with a unified CI pipeline that detects desktop support, runs web quality + PR coverage, and executes desktop compile checks across Linux/macOS/Windows
- add a new tag-triggered unified release workflow that ships a web artifact and (when `src-tauri` exists) signed desktop bundles with per-stage job summaries
- add desktop release helper scripts for signing-env validation and package/Tauri version synchronization, and wire them into `package.json` + version bump automation
- document workflow behavior and required release secrets in the README

## Issue Context
Phonograph needs production-grade unified automation for both web and desktop delivery surfaces with explicit, human-readable status summaries in GitHub Actions.

## Validation
- `yarn install --frozen-lockfile`
- `node scripts/sync-desktop-version.mjs`
- `node scripts/validate-desktop-signing-env.mjs`
- `node --check scripts/bump-version.mjs`
- `node --check scripts/sync-desktop-version.mjs`
- `node --check scripts/validate-desktop-signing-env.mjs`
- `yarn typecheck`
- `yarn lint:errors`
- `yarn test`

## Rollout Notes
- set repository secrets before cutting release tags: `LISTEN_NOTES_API_KEY` (or `LISTENNOTES`), plus macOS/Windows signing secrets for desktop releases
- desktop release jobs are automatically skipped if `src-tauri/tauri.conf.json` is not present
- release artifacts are published to a draft GitHub release for manual QA before publication
