### PR TITLE
feat(desktop): harden tauri platform URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ Build pipeline (`yarn build`) includes:
 
 - `LISTEN_NOTES_API_KEY` (preferred)
 - `LISTENNOTES` / `listennotes` (backward-compatible alternatives)
+- `VITE_DESKTOP_API_ORIGIN` (optional; desktop backend origin, defaults to `https://phonograph.app`)
+- `VITE_PUBLIC_WEB_ORIGIN` (optional; desktop share-link origin, defaults to `https://phonograph.app`)
 
 These are used for discovery/proxy calls that depend on Listen Notes.
+
+Desktop parity status and release-readiness notes are tracked in `docs/desktop-parity.md`.
 
 ## Quality and Testing
 

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -1,0 +1,26 @@
+# Desktop Parity Status
+
+This document tracks web/desktop parity for the Phonograph v1 playback journeys.
+
+## Core Flow Coverage
+
+- ✅ Discover view runs in desktop shell with Apple/Listen Notes requests resolved through the platform adapter.
+- ✅ Library and podcast detail flows run in desktop shell through shared reducer/state modules.
+- ✅ Playlist and playback controls run in desktop shell through shared player modules.
+- ✅ Settings flow runs in desktop shell, including OPML import/export with native dialogs.
+
+## Adapter Boundaries
+
+Desktop-specific behavior is isolated in `src/platform/`:
+
+- `registerServiceWorker`: enabled on web, no-op on desktop.
+- `resolveBackendUrl`: resolves desktop API paths to hosted or configured backend origins.
+- `resolveShareUrl`: ensures desktop share links target the public web origin.
+
+Domain/UI modules in `src/podcast`, `src/core`, `src/engine`, and `src/store` consume adapter functions instead of hard-coding runtime assumptions.
+
+## Operational Notes
+
+1. Desktop defaults to `https://phonograph.app` for backend/share origins.
+2. Override desktop origins with `VITE_DESKTOP_API_ORIGIN` and `VITE_PUBLIC_WEB_ORIGIN` for staging or self-hosted environments.
+3. Desktop signing and notarization pipelines remain a release engineering follow-up.

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,15 +1,13 @@
 import PodcastEngine from "podcastsuite";
 import { podcasts } from "../podcast";
 import { AppAction } from "../types/app";
+import platform from "../platform";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
-const HOST =
-  typeof window !== "undefined" && window.location ? window.location.host : "";
-
 const PROXY = {
-  "https:": `//${HOST}/rss-full/?term=https://`,
-  "http:": `//${HOST}/rss-full/?term=http://`,
+  "https:": platform.resolveBackendUrl("/rss-full/?term=https://"),
+  "http:": platform.resolveBackendUrl("/rss-full/?term=http://"),
 };
 
 export const checkIfNewPodcastInURL = () => {

--- a/src/platform/index.test.ts
+++ b/src/platform/index.test.ts
@@ -6,11 +6,26 @@ describe("platform adapter", () => {
     const adapter = createPlatformAdapter(false);
     expect(adapter.runtime).toBe("web");
     expect(adapter.isDesktop).toBe(false);
+    expect(adapter.resolveBackendUrl("/apple/search?term=foo")).toBe("/apple/search?term=foo");
+    expect(adapter.resolveShareUrl("/podcast/abc")).toContain("/podcast/abc");
   });
 
   it("returns tauri adapter when tauri runtime is active", () => {
     const adapter = createPlatformAdapter(true);
     expect(adapter.runtime).toBe("tauri");
     expect(adapter.isDesktop).toBe(true);
+    expect(adapter.resolveBackendUrl("/apple/search?term=foo")).toBe("https://phonograph.app/apple/search?term=foo");
+    expect(adapter.resolveShareUrl("/podcast/abc")).toBe("https://phonograph.app/podcast/abc");
+  });
+
+  it("preserves fully-qualified URLs", () => {
+    const webAdapter = createPlatformAdapter(false);
+    const tauriAdapter = createPlatformAdapter(true);
+    const absoluteUrl = "https://example.com/path";
+
+    expect(webAdapter.resolveBackendUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(tauriAdapter.resolveBackendUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(webAdapter.resolveShareUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(tauriAdapter.resolveShareUrl(absoluteUrl)).toBe(absoluteUrl);
   });
 });

--- a/src/platform/tauri.test.ts
+++ b/src/platform/tauri.test.ts
@@ -10,5 +10,12 @@ describe("tauri platform adapter", () => {
   it("uses a no-op service worker registration", () => {
     expect(() => tauriAdapter.registerServiceWorker()).not.toThrow();
   });
-});
 
+  it("resolves backend URLs to the hosted API origin", () => {
+    expect(tauriAdapter.resolveBackendUrl("/ln/search?q=test")).toBe("https://phonograph.app/ln/search?q=test");
+  });
+
+  it("resolves share URLs to the public web origin", () => {
+    expect(tauriAdapter.resolveShareUrl("/podcast/abc")).toBe("https://phonograph.app/podcast/abc");
+  });
+});

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -1,9 +1,49 @@
 import type { PlatformAdapter } from "./types";
 
+const DEFAULT_PUBLIC_WEB_ORIGIN = "https://phonograph.app";
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const resolveDesktopBackendOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_DESKTOP_API_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  if (import.meta.env.DEV && typeof window !== "undefined" && window.location?.origin) {
+    return trimTrailingSlash(window.location.origin);
+  }
+
+  return DEFAULT_PUBLIC_WEB_ORIGIN;
+};
+
+const resolvePublicWebOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_PUBLIC_WEB_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  return DEFAULT_PUBLIC_WEB_ORIGIN;
+};
+
+const toAbsoluteUrl = (origin: string, path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  return `${trimTrailingSlash(origin)}${withLeadingSlash(path)}`;
+};
+
 const tauriAdapter: PlatformAdapter = {
   runtime: "tauri",
   isDesktop: true,
   registerServiceWorker: () => {},
+  resolveBackendUrl: (path: string) => toAbsoluteUrl(resolveDesktopBackendOrigin(), path),
+  resolveShareUrl: (path: string) => toAbsoluteUrl(resolvePublicWebOrigin(), path),
 };
 
 export default tauriAdapter;

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -4,4 +4,6 @@ export interface PlatformAdapter {
   runtime: PlatformRuntime;
   isDesktop: boolean;
   registerServiceWorker: () => void;
+  resolveBackendUrl: (path: string) => string;
+  resolveShareUrl: (path: string) => string;
 }

--- a/src/platform/web.test.ts
+++ b/src/platform/web.test.ts
@@ -11,5 +11,12 @@ describe("web platform adapter", () => {
     webAdapter.registerServiceWorker();
     expect(serviceWorker).toHaveBeenCalledTimes(1);
   });
-});
 
+  it("keeps backend URLs relative for proxying", () => {
+    expect(webAdapter.resolveBackendUrl("/ln/search?q=test")).toBe("/ln/search?q=test");
+  });
+
+  it("builds share URLs from current origin", () => {
+    expect(webAdapter.resolveShareUrl("/podcast/abc")).toContain("/podcast/abc");
+  });
+});

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -1,12 +1,26 @@
 import serviceWorker from "../serviceworker";
 import type { PlatformAdapter } from "./types";
 
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const resolveWithCurrentOrigin = (path: string) => {
+  if (isAbsoluteUrl(path) || typeof window === "undefined" || !window.location) {
+    return path;
+  }
+
+  return `${window.location.origin}${withLeadingSlash(path)}`;
+};
+
 const webAdapter: PlatformAdapter = {
   runtime: "web",
   isDesktop: false,
   registerServiceWorker: () => {
     serviceWorker();
   },
+  resolveBackendUrl: (path: string) => path,
+  resolveShareUrl: resolveWithCurrentOrigin,
 };
 
 export default webAdapter;

--- a/src/podcast/Discovery/PodcastSearcher.ts
+++ b/src/podcast/Discovery/PodcastSearcher.ts
@@ -1,3 +1,5 @@
+import platform from "../../platform";
+
 export interface PodcastSearchResponse {
   results?: Array<Record<string, any>>;
   [key: string]: any;
@@ -36,17 +38,17 @@ export default class PodcastSearcher {
     this.currentRequest = new AbortController();
     const { signal } = this.currentRequest;
     return new Promise((accept, reject) =>
-      fetch(`/ln/search?type=podcast&q=${encodeURIComponent(term)}`, { signal })
+      fetch(platform.resolveBackendUrl(`/ln/search?type=podcast&q=${encodeURIComponent(term)}`), { signal })
         .then((result) => (result.ok && result.json().then(accept).catch(reject)) || reject(result))
         .catch(reject)
     );
   }
 
   listennotes(term: string): Promise<PodcastSearchResponse> {
-    return this.querySearch(`/ln/typeahead?q=${encodeURIComponent(term)}&show_podcasts=1`);
+    return this.querySearch(platform.resolveBackendUrl(`/ln/typeahead?q=${encodeURIComponent(term)}&show_podcasts=1`));
   }
 
   apple(term: string): Promise<PodcastSearchResponse> {
-    return this.querySearch(`/apple/search?term=${encodeURIComponent(term)}`);
+    return this.querySearch(platform.resolveBackendUrl(`/apple/search?term=${encodeURIComponent(term)}`));
   }
 }

--- a/src/podcast/Discovery/engine.ts
+++ b/src/podcast/Discovery/engine.ts
@@ -1,6 +1,7 @@
 import PodcastSearcher, { PodcastSearchResponse } from "./PodcastSearcher";
 import { appleCacheKey, getBrowserCached, setBrowserCached } from "./appleBrowserCache";
 import { bestPodcastsCacheKey, getCachedBestPodcasts, setCachedBestPodcasts } from "./popularCache";
+import platform from "../../platform";
 
 export interface PodcastSearchResult {
   title: string;
@@ -107,7 +108,7 @@ export const getPopularPodcasts = async function (query: number | null = null): 
     if (cached) return cached;
 
     try {
-      const resp = await fetch(`/apple/rss/${storefront}/podcasts/top/${limit}/podcasts.json`);
+      const resp = await fetch(platform.resolveBackendUrl(`/apple/rss/${storefront}/podcasts/top/${limit}/podcasts.json`));
       if (!resp.ok) throw new Error(`Apple top failed: ${resp.status}`);
       const data = await resp.json();
       const results = (data && data.feed && data.feed.results) || [];
@@ -157,7 +158,7 @@ export const getPopularPodcasts = async function (query: number | null = null): 
 
   const URI = "https://www.listennotes.com/c/r/";
   try {
-    const resp = await fetch(`/ln/best_podcasts?${params}`);
+    const resp = await fetch(platform.resolveBackendUrl(`/ln/best_podcasts?${params}`));
     if (!resp.ok) throw new Error(`Listen Notes best_podcasts failed: ${resp.status}`);
     const data = await resp.json();
     const { podcasts = [], name } = data;
@@ -201,7 +202,7 @@ export const resolveApplePodcastFeedUrl = async (appleId: string): Promise<strin
   const cached = await getBrowserCached<string>(cacheKey);
   if (cached) return cached;
 
-  const resp = await fetch(`/apple/lookup?id=${encodeURIComponent(id)}`);
+  const resp = await fetch(platform.resolveBackendUrl(`/apple/lookup?id=${encodeURIComponent(id)}`));
   if (!resp.ok) return null;
   const data = await resp.json();
   const result = (data && data.results && data.results[0]) || null;
@@ -238,7 +239,7 @@ export const getApplePodcastGenres = async (): Promise<PodcastGenre[]> => {
   const cached = await getBrowserCached<PodcastGenre[]>(cacheKey);
   if (cached) return cached;
 
-  const resp = await fetch(`/apple/genres?id=26`);
+  const resp = await fetch(platform.resolveBackendUrl("/apple/genres?id=26"));
   if (!resp.ok) return [];
   const data = await resp.json();
 

--- a/src/podcast/Discovery/index.tsx
+++ b/src/podcast/Discovery/index.tsx
@@ -19,6 +19,7 @@ import Search from "./Search";
 import Geners from "./Geners";
 import Loading from "../../core/Loading";
 import HeroCarousel from "./HeroCarousel";
+import platform from "../../platform";
 
 import {
   getPopularPodcasts,
@@ -44,7 +45,7 @@ const Header: React.FC = () => (
 );
 
 const getFinalURL = async (url: string): Promise<string> => {
-  const URL = `${window.location.origin}/api/findFinal/?term=${encodeURIComponent(url)}`;
+  const URL = platform.resolveBackendUrl(`/api/findFinal/?term=${encodeURIComponent(url)}`);
   try {
     const data = await fetch(URL);
     const result = await data.json();

--- a/src/podcast/PodcastView/PodcastHeader.tsx
+++ b/src/podcast/PodcastView/PodcastHeader.tsx
@@ -27,6 +27,7 @@ import { clearText } from "./EpisodeList";
 import { Consumer } from "../../App";
 import { useHistory } from "react-router-dom";
 import { buildThemeFromPalette, toRGBA } from "../../core/podcastPalette";
+import platform from "../../platform";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 const prod = DEBUG ? '' : ''
@@ -174,7 +175,7 @@ function PodcastHeader(props) {
                           onClick={share(
                             "Phonograph",
                             state.title,
-                            `${document.location.origin}/podcast/${makeMeAHash(state.domain)}`
+                            platform.resolveShareUrl(`/podcast/${makeMeAHash(state.domain)}`)
                           )}
                         >
                           <ShareIcon />

--- a/src/serviceworker/worker.ts
+++ b/src/serviceworker/worker.ts
@@ -2,14 +2,44 @@ import PodcastEngine from "podcastsuite";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
+const DEFAULT_DESKTOP_API_ORIGIN = "https://phonograph.app";
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const resolveDesktopBackendOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_DESKTOP_API_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  return DEFAULT_DESKTOP_API_ORIGIN;
+};
+
+const resolveBackendUrl = (path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  const normalizedPath = withLeadingSlash(path);
+  if (location.protocol === "tauri:") {
+    return `${resolveDesktopBackendOrigin()}${normalizedPath}`;
+  }
+
+  return `//${location.host}${normalizedPath}`;
+};
+
 const proxy = DEBUG
   ? {
-      "https:": `//${location.host}/rss-full/?term=https://`,
-      "http:": `//${location.host}/rss-full/?term=http://`,
+      "https:": resolveBackendUrl("/rss-full/?term=https://"),
+      "http:": resolveBackendUrl("/rss-full/?term=http://"),
     }
   : {
-      "https:": `//${location.host}/rss-full/https://`,
-      "http:": `//${location.host}/rss-full/http://`,
+      "https:": resolveBackendUrl("/rss-full/https://"),
+      "http:": resolveBackendUrl("/rss-full/http://"),
     };
 
 const getPodcastEngine = (shouldInit = false) =>

--- a/src/types/vite-env.d.ts
+++ b/src/types/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION?: string;
   readonly VITE_COMMIT_REF?: string;
   readonly VITE_DEPLOY_ID?: string;
+  readonly VITE_DESKTOP_API_ORIGIN?: string;
+  readonly VITE_PUBLIC_WEB_ORIGIN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- harden the platform adapter with explicit backend/share URL resolvers for Tauri runtime
- route discovery, podcast detail fetches, engine proxies, and worker refresh traffic through adapter-based URL resolution
- add desktop parity documentation and adapter-focused tests covering web + tauri URL behaviors

## Issue Context
Desktop Tauri builds can run under a non-http app origin (`tauri://localhost`), so directly using relative API/share paths breaks provider calls and generated share URLs. This change centralizes runtime URL behavior behind the platform boundary and defaults desktop API/share origins to `https://phonograph.app` with env overrides.

## Validation
- `yarn test src/platform/index.test.ts src/platform/tauri.test.ts src/platform/web.test.ts src/platform/opmlDialogs.test.ts src/podcast/Discovery/engine.test.ts`
- `yarn typecheck`
- `yarn lint:errors`

## Rollout Notes
1. Desktop builds default to production backend/share origins immediately.
2. For staging/self-hosted desktop builds, set `VITE_DESKTOP_API_ORIGIN` and `VITE_PUBLIC_WEB_ORIGIN` at build time.
3. No migration is needed for web runtime; web keeps relative backend paths for local proxying.
