### PR TITLE
feat: harden Tauri desktop platform integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ yarn start
 yarn desktop:dev
 ```
 
+`desktop:dev` and `desktop:build` automatically sync `src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` versions from `package.json`.
+
 Build desktop bundles:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
   ],
   "scripts": {
     "start": "vite",
+    "desktop:sync-version": "node scripts/sync-tauri-version.mjs",
+    "predesktop:dev": "yarn desktop:sync-version",
     "desktop:dev": "tauri dev",
+    "predesktop:build": "yarn desktop:sync-version",
     "desktop:build": "tauri build",
     "build": "yarn getter && vite build && yarn SEO && yarn sw && yarn docs:manuals:build && yarn lambda:build",
     "serve": "vite preview",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -66,3 +66,17 @@ if (fs.existsSync(tauriConfigPath)) {
     // Ignore tauri config updates if the file is malformed.
   }
 }
+
+const tauriCargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
+if (fs.existsSync(tauriCargoTomlPath)) {
+  try {
+    const cargoToml = fs.readFileSync(tauriCargoTomlPath, "utf8");
+    const updatedCargoToml = cargoToml.replace(/(\[package\][\s\S]*?\nversion\s*=\s*")([^"]+)(")/, `$1${next}$3`);
+
+    if (updatedCargoToml !== cargoToml) {
+      fs.writeFileSync(tauriCargoTomlPath, updatedCargoToml);
+    }
+  } catch (e) {
+    // Ignore Cargo.toml updates if the file is malformed.
+  }
+}

--- a/scripts/sync-tauri-version.mjs
+++ b/scripts/sync-tauri-version.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 const repoRoot = process.cwd();
 const packageJsonPath = path.join(repoRoot, "package.json");
 const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+const tauriCargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
 
 if (!fs.existsSync(packageJsonPath) || !fs.existsSync(tauriConfigPath)) {
   process.exit(0);
@@ -20,5 +21,17 @@ if (!packageJson.version || typeof packageJson.version !== "string") {
 
 tauriConfig.version = packageJson.version;
 fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
+
+if (fs.existsSync(tauriCargoTomlPath)) {
+  const cargoToml = fs.readFileSync(tauriCargoTomlPath, "utf8");
+  const updatedCargoToml = cargoToml.replace(
+    /(\[package\][\s\S]*?\nversion\s*=\s*")([^"]+)(")/,
+    `$1${packageJson.version}$3`
+  );
+
+  if (updatedCargoToml !== cargoToml) {
+    fs.writeFileSync(tauriCargoTomlPath, updatedCargoToml);
+  }
+}
 
 process.stdout.write(packageJson.version);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2294,10 +2294,12 @@ dependencies = [
 
 [[package]]
 name = "phonograph_desktop"
-version = "0.1.0"
+version = "1.3.24"
 dependencies = [
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
 ]
 
 [[package]]
@@ -2670,6 +2672,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3372,6 +3398,63 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phonograph_desktop"
-version = "0.1.0"
+version = "1.3.24"
 description = "Phonograph desktop shell"
 authors = ["Phonograph Team"]
 edition = "2021"
@@ -10,6 +10,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,9 @@
   "identifier": "default",
   "description": "Default capabilities for the main desktop window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "dialog:default",
+    "fs:default"
+  ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
 
 fn main() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_fs::init())
     .run(tauri::generate_context!())
     .expect("error while running phonograph desktop shell");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phonograph",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "identifier": "app.phonograph.desktop",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -21,7 +21,7 @@
     ]
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
     "icon": [
       "../public/android-chrome-512x512.png",


### PR DESCRIPTION
## Issue context
- Desktop shell had partial Tauri wiring: native dialog/fs plugins were not registered, capabilities only allowed core defaults, and local desktop commands did not auto-sync desktop versions with `package.json`.
- `tauri.conf.json` bundling was disabled and Tauri version drifted from the app release version.

## What changed
- Registered `tauri-plugin-dialog` and `tauri-plugin-fs` in `src-tauri/src/main.rs`.
- Added Rust plugin dependencies and aligned desktop crate version to app version in `src-tauri/Cargo.toml` and lockfile.
- Expanded desktop capability permissions to include `dialog:default` and `fs:default`.
- Enabled desktop bundling and aligned `src-tauri/tauri.conf.json` version with the app.
- Added `desktop:sync-version` and automatic pre-hooks for `desktop:dev` and `desktop:build`.
- Extended version scripts to sync both `src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` from `package.json`.
- Documented automatic desktop version sync in `README.md`.

## Validation
- `node scripts/sync-tauri-version.mjs`
- `yarn test src/platform/opmlDialogs.test.ts`
- `yarn typecheck`
- `yarn lint:errors`
- `cargo metadata --manifest-path src-tauri/Cargo.toml --locked --no-deps`

## Rollout notes
- CI desktop jobs now exercise plugin-enabled Tauri compile/package paths with updated lock/config.
- Full local `cargo check` was attempted but blocked by local disk capacity (`No space left on device`); CI should perform full compile validation.