### PR TITLE
feat(desktop): harden tauri runtime boundaries and release version sync

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Sync Tauri version with package version
-        run: node scripts/sync-tauri-version.mjs
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -37,12 +37,31 @@ jobs:
         run: node scripts/bump-version.mjs patch
 
       - name: Commit and tag
+        id: commit_tag
         if: steps.check.outputs.skip != 'true'
         run: |
           next="$(node -p "require('./package.json').version")"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json || true
+
+          git add package.json
+
+          if [ -f package-lock.json ]; then
+            git add package-lock.json
+          fi
+
+          if [ -f src-tauri/tauri.conf.json ]; then
+            git add src-tauri/tauri.conf.json
+          fi
+
+          if [ -f src-tauri/Cargo.toml ]; then
+            git add src-tauri/Cargo.toml
+          fi
+
+          if [ -f src-tauri/Cargo.lock ]; then
+            git add src-tauri/Cargo.lock
+          fi
+
           if git diff --cached --quiet; then
             echo "No version changes to commit."
             exit 0
@@ -51,3 +70,17 @@ jobs:
           git tag "v$next"
           git push
           git push --tags
+
+      - name: Report version bump status
+        if: always()
+        run: |
+          {
+            echo "## Version bump"
+            echo "- Release bump skipped: ${{ steps.check.outputs.skip }}"
+            echo "- Commit + tag step: ${{ steps.commit_tag.outcome || 'skipped' }}"
+            if [ "${{ steps.check.outputs.skip }}" = "true" ]; then
+              echo "- Existing release commit detected; no new tag created."
+            else
+              echo "- Patch version bump attempted."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ Build pipeline (`yarn build`) includes:
 
 - `LISTEN_NOTES_API_KEY` (preferred)
 - `LISTENNOTES` / `listennotes` (backward-compatible alternatives)
+- `VITE_DESKTOP_API_ORIGIN` (optional; desktop backend origin, defaults to `https://phonograph.app`)
+- `VITE_PUBLIC_WEB_ORIGIN` (optional; desktop share-link origin, defaults to `https://phonograph.app`)
 
 These are used for discovery/proxy calls that depend on Listen Notes.
+
+Desktop parity status and release-readiness notes are tracked in `docs/desktop-parity.md`.
 
 ## Quality and Testing
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ Build desktop bundles:
 yarn desktop:build
 ```
 
+Synchronize desktop manifest versions only:
+
+```bash
+yarn desktop:sync-version
+```
+
+CI/release desktop build (includes signing-env validation):
+
+```bash
+yarn desktop:build:ci
+```
+
 ### Desktop release + download links
 
 - Pushing a semver tag (for example `v1.3.24`) triggers `.github/workflows/desktop-release-macos.yml`.
@@ -197,6 +209,10 @@ Build pipeline (`yarn build`) includes:
 - `LISTENNOTES` / `listennotes` (backward-compatible alternatives)
 - `VITE_DESKTOP_API_ORIGIN` (optional; desktop backend origin, defaults to `https://phonograph.app`)
 - `VITE_PUBLIC_WEB_ORIGIN` (optional; desktop share-link origin, defaults to `https://phonograph.app`)
+
+Desktop signing validation checks these env vars when running on release refs (or with `--force`):
+- macOS: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PATH`
+- Windows: `TAURI_WINDOWS_CERTIFICATE`, `TAURI_WINDOWS_CERTIFICATE_PASSWORD`
 
 These are used for discovery/proxy calls that depend on Listen Notes.
 

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -1,0 +1,26 @@
+# Desktop Parity Status
+
+This document tracks web/desktop parity for the Phonograph v1 playback journeys.
+
+## Core Flow Coverage
+
+- ✅ Discover view runs in desktop shell with Apple/Listen Notes requests resolved through the platform adapter.
+- ✅ Library and podcast detail flows run in desktop shell through shared reducer/state modules.
+- ✅ Playlist and playback controls run in desktop shell through shared player modules.
+- ✅ Settings flow runs in desktop shell, including OPML import/export with native dialogs.
+
+## Adapter Boundaries
+
+Desktop-specific behavior is isolated in `src/platform/`:
+
+- `registerServiceWorker`: enabled on web, no-op on desktop.
+- `resolveBackendUrl`: resolves desktop API paths to hosted or configured backend origins.
+- `resolveShareUrl`: ensures desktop share links target the public web origin.
+
+Domain/UI modules in `src/podcast`, `src/core`, `src/engine`, and `src/store` consume adapter functions instead of hard-coding runtime assumptions.
+
+## Operational Notes
+
+1. Desktop defaults to `https://phonograph.app` for backend/share origins.
+2. Override desktop origins with `VITE_DESKTOP_API_ORIGIN` and `VITE_PUBLIC_WEB_ORIGIN` for staging or self-hosted environments.
+3. Desktop signing and notarization pipelines remain a release engineering follow-up.

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   ],
   "scripts": {
     "start": "vite",
-    "desktop:dev": "tauri dev",
-    "desktop:build": "tauri build",
+    "desktop:sync-version": "node scripts/sync-tauri-version.mjs",
+    "desktop:dev": "yarn desktop:sync-version && tauri dev",
+    "desktop:build": "yarn desktop:sync-version && tauri build",
+    "desktop:build:ci": "yarn desktop:sync-version && node scripts/validate-desktop-signing-env.mjs && tauri build",
     "build": "yarn getter && vite build && yarn SEO && yarn sw && yarn docs:manuals:build && yarn lambda:build",
     "serve": "vite preview",
     "docs:manuals:dev": "vitepress dev manuals",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -32,6 +32,61 @@ const bump = (version, type) => {
   return `${major}.${minor}.${patch + 1}`;
 };
 
+const parseCargoPackageName = (cargoToml) => {
+  const match = cargoToml.match(/^name\s*=\s*"([^"]+)"$/m);
+  if (!match) {
+    throw new Error("Unable to determine Cargo package name from src-tauri/Cargo.toml");
+  }
+
+  return match[1];
+};
+
+const syncCargoLockVersion = ({ cargoLockPath, cargoPackageName, version }) => {
+  if (!fs.existsSync(cargoLockPath)) {
+    return;
+  }
+
+  const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedPackageName = escapeRegex(cargoPackageName);
+  const cargoLock = fs.readFileSync(cargoLockPath, "utf8");
+  const packageVersionPattern = new RegExp(
+    `(\\[\\[package\\]\\][\\r\\n]+name = \"${escapedPackageName}\"[\\r\\n]+version = \")[^\"]+(\")`,
+    "m"
+  );
+
+  const updatedCargoLock = cargoLock.replace(packageVersionPattern, `$1${version}$2`);
+
+  if (updatedCargoLock !== cargoLock) {
+    fs.writeFileSync(cargoLockPath, updatedCargoLock);
+  }
+};
+
+const syncDesktopVersion = (version) => {
+  const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+  const cargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
+  const cargoLockPath = path.join(repoRoot, "src-tauri", "Cargo.lock");
+
+  if (!fs.existsSync(tauriConfigPath) || !fs.existsSync(cargoTomlPath)) {
+    return;
+  }
+
+  const tauriConfig = readJson(tauriConfigPath);
+  if (tauriConfig.version !== version) {
+    tauriConfig.version = version;
+    writeJson(tauriConfigPath, tauriConfig);
+  }
+
+  const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
+  const cargoPackageName = parseCargoPackageName(cargoToml);
+  const updatedCargoToml = cargoToml.replace(/^(version\s*=\s*").*(")$/m, `$1${version}$2`);
+
+  if (updatedCargoToml !== cargoToml) {
+    fs.writeFileSync(cargoTomlPath, updatedCargoToml);
+  }
+
+  syncCargoLockVersion({ cargoLockPath, cargoPackageName, version });
+};
+
 const pkgPath = path.join(repoRoot, "package.json");
 const pkg = readJson(pkgPath);
 const current = pkg.version;
@@ -54,15 +109,6 @@ if (fs.existsSync(lockPath)) {
   }
 }
 
-process.stdout.write(next);
+syncDesktopVersion(next);
 
-const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
-if (fs.existsSync(tauriConfigPath)) {
-  try {
-    const tauriConfig = readJson(tauriConfigPath);
-    tauriConfig.version = next;
-    fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
-  } catch (e) {
-    // Ignore tauri config updates if the file is malformed.
-  }
-}
+process.stdout.write(next);

--- a/scripts/sync-tauri-version.mjs
+++ b/scripts/sync-tauri-version.mjs
@@ -6,19 +6,62 @@ import path from "node:path";
 const repoRoot = process.cwd();
 const packageJsonPath = path.join(repoRoot, "package.json");
 const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+const cargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
+const cargoLockPath = path.join(repoRoot, "src-tauri", "Cargo.lock");
 
-if (!fs.existsSync(packageJsonPath) || !fs.existsSync(tauriConfigPath)) {
+const parseCargoPackageName = (cargoToml) => {
+  const match = cargoToml.match(/^name\s*=\s*"([^"]+)"$/m);
+  if (!match) {
+    throw new Error("Unable to determine Cargo package name from src-tauri/Cargo.toml");
+  }
+
+  return match[1];
+};
+
+const syncCargoLockVersion = ({ cargoPackageName, version }) => {
+  if (!fs.existsSync(cargoLockPath)) {
+    return;
+  }
+
+  const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedPackageName = escapeRegex(cargoPackageName);
+  const cargoLock = fs.readFileSync(cargoLockPath, "utf8");
+  const packageVersionPattern = new RegExp(
+    `(\\[\\[package\\]\\][\\r\\n]+name = \"${escapedPackageName}\"[\\r\\n]+version = \")[^\"]+(\")`,
+    "m"
+  );
+
+  const updatedCargoLock = cargoLock.replace(packageVersionPattern, `$1${version}$2`);
+
+  if (updatedCargoLock !== cargoLock) {
+    fs.writeFileSync(cargoLockPath, updatedCargoLock);
+  }
+};
+
+if (!fs.existsSync(packageJsonPath) || !fs.existsSync(tauriConfigPath) || !fs.existsSync(cargoTomlPath)) {
   process.exit(0);
 }
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, "utf8"));
+const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
 
 if (!packageJson.version || typeof packageJson.version !== "string") {
   throw new Error("package.json version is missing or invalid");
 }
 
-tauriConfig.version = packageJson.version;
-fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
+const version = packageJson.version;
 
-process.stdout.write(packageJson.version);
+tauriConfig.version = version;
+fs.writeFileSync(tauriConfigPath, `${JSON.stringify(tauriConfig, null, 2)}\n`);
+
+const cargoPackageName = parseCargoPackageName(cargoToml);
+const updatedCargoToml = cargoToml.replace(/^(version\s*=\s*").*(")$/m, `$1${version}$2`);
+
+if (updatedCargoToml !== cargoToml) {
+  fs.writeFileSync(cargoTomlPath, updatedCargoToml);
+}
+
+syncCargoLockVersion({ cargoPackageName, version });
+
+process.stdout.write(`Desktop version synchronized to ${version}\n`);

--- a/scripts/validate-desktop-signing-env.mjs
+++ b/scripts/validate-desktop-signing-env.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const hasDesktopConfig = fs.existsSync(path.join(root, "src-tauri", "tauri.conf.json"));
+
+if (!hasDesktopConfig) {
+  process.stdout.write("Desktop workspace not found, skipping signing validation.\n");
+  process.exit(0);
+}
+
+const isCi = process.env.CI === "true";
+const isReleaseRef = process.env.GITHUB_REF_TYPE === "tag";
+const shouldEnforce = process.argv.includes("--force") || (isCi && isReleaseRef);
+
+if (!shouldEnforce) {
+  process.stdout.write("Skipping desktop signing environment validation.\n");
+  process.exit(0);
+}
+
+const missing = [];
+
+const requireEnv = (name) => {
+  if (!process.env[name]) {
+    missing.push(name);
+  }
+};
+
+const platform = process.platform;
+if (platform === "darwin") {
+  requireEnv("APPLE_CERTIFICATE");
+  requireEnv("APPLE_CERTIFICATE_PASSWORD");
+  requireEnv("APPLE_SIGNING_IDENTITY");
+  requireEnv("APPLE_API_ISSUER");
+  requireEnv("APPLE_API_KEY");
+  requireEnv("APPLE_API_KEY_PATH");
+}
+
+if (platform === "win32") {
+  requireEnv("TAURI_WINDOWS_CERTIFICATE");
+  requireEnv("TAURI_WINDOWS_CERTIFICATE_PASSWORD");
+}
+
+if (missing.length > 0) {
+  console.error("Missing required desktop signing environment variables:");
+  for (const variableName of missing) {
+    console.error(`- ${variableName}`);
+  }
+  process.exit(1);
+}
+
+process.stdout.write("Desktop signing environment validation passed.\n");

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "phonograph_desktop"
-version = "0.1.0"
+version = "1.3.24"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phonograph_desktop"
-version = "0.1.0"
+version = "1.3.24"
 description = "Phonograph desktop shell"
 authors = ["Phonograph Team"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phonograph",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "identifier": "app.phonograph.desktop",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -21,7 +21,7 @@
     ]
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
     "icon": [
       "../public/android-chrome-512x512.png",

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,15 +1,13 @@
 import PodcastEngine from "podcastsuite";
 import { podcasts } from "../podcast";
 import { AppAction } from "../types/app";
+import platform from "../platform";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
-const HOST =
-  typeof window !== "undefined" && window.location ? window.location.host : "";
-
 const PROXY = {
-  "https:": `//${HOST}/rss-full/?term=https://`,
-  "http:": `//${HOST}/rss-full/?term=http://`,
+  "https:": platform.resolveBackendUrl("/rss-full/?term=https://"),
+  "http:": platform.resolveBackendUrl("/rss-full/?term=http://"),
 };
 
 export const checkIfNewPodcastInURL = () => {

--- a/src/platform/index.test.ts
+++ b/src/platform/index.test.ts
@@ -6,11 +6,26 @@ describe("platform adapter", () => {
     const adapter = createPlatformAdapter(false);
     expect(adapter.runtime).toBe("web");
     expect(adapter.isDesktop).toBe(false);
+    expect(adapter.resolveBackendUrl("/apple/search?term=foo")).toBe("/apple/search?term=foo");
+    expect(adapter.resolveShareUrl("/podcast/abc")).toContain("/podcast/abc");
   });
 
   it("returns tauri adapter when tauri runtime is active", () => {
     const adapter = createPlatformAdapter(true);
     expect(adapter.runtime).toBe("tauri");
     expect(adapter.isDesktop).toBe(true);
+    expect(adapter.resolveBackendUrl("/apple/search?term=foo")).toBe("https://phonograph.app/apple/search?term=foo");
+    expect(adapter.resolveShareUrl("/podcast/abc")).toBe("https://phonograph.app/podcast/abc");
+  });
+
+  it("preserves fully-qualified URLs", () => {
+    const webAdapter = createPlatformAdapter(false);
+    const tauriAdapter = createPlatformAdapter(true);
+    const absoluteUrl = "https://example.com/path";
+
+    expect(webAdapter.resolveBackendUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(tauriAdapter.resolveBackendUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(webAdapter.resolveShareUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(tauriAdapter.resolveShareUrl(absoluteUrl)).toBe(absoluteUrl);
   });
 });

--- a/src/platform/tauri.test.ts
+++ b/src/platform/tauri.test.ts
@@ -10,5 +10,12 @@ describe("tauri platform adapter", () => {
   it("uses a no-op service worker registration", () => {
     expect(() => tauriAdapter.registerServiceWorker()).not.toThrow();
   });
-});
 
+  it("resolves backend URLs to the hosted API origin", () => {
+    expect(tauriAdapter.resolveBackendUrl("/ln/search?q=test")).toBe("https://phonograph.app/ln/search?q=test");
+  });
+
+  it("resolves share URLs to the public web origin", () => {
+    expect(tauriAdapter.resolveShareUrl("/podcast/abc")).toBe("https://phonograph.app/podcast/abc");
+  });
+});

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -1,9 +1,49 @@
 import type { PlatformAdapter } from "./types";
 
+const DEFAULT_PUBLIC_WEB_ORIGIN = "https://phonograph.app";
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const resolveDesktopBackendOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_DESKTOP_API_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  if (import.meta.env.DEV && typeof window !== "undefined" && window.location?.origin) {
+    return trimTrailingSlash(window.location.origin);
+  }
+
+  return DEFAULT_PUBLIC_WEB_ORIGIN;
+};
+
+const resolvePublicWebOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_PUBLIC_WEB_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  return DEFAULT_PUBLIC_WEB_ORIGIN;
+};
+
+const toAbsoluteUrl = (origin: string, path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  return `${trimTrailingSlash(origin)}${withLeadingSlash(path)}`;
+};
+
 const tauriAdapter: PlatformAdapter = {
   runtime: "tauri",
   isDesktop: true,
   registerServiceWorker: () => {},
+  resolveBackendUrl: (path: string) => toAbsoluteUrl(resolveDesktopBackendOrigin(), path),
+  resolveShareUrl: (path: string) => toAbsoluteUrl(resolvePublicWebOrigin(), path),
 };
 
 export default tauriAdapter;

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -4,4 +4,6 @@ export interface PlatformAdapter {
   runtime: PlatformRuntime;
   isDesktop: boolean;
   registerServiceWorker: () => void;
+  resolveBackendUrl: (path: string) => string;
+  resolveShareUrl: (path: string) => string;
 }

--- a/src/platform/web.test.ts
+++ b/src/platform/web.test.ts
@@ -11,5 +11,12 @@ describe("web platform adapter", () => {
     webAdapter.registerServiceWorker();
     expect(serviceWorker).toHaveBeenCalledTimes(1);
   });
-});
 
+  it("keeps backend URLs relative for proxying", () => {
+    expect(webAdapter.resolveBackendUrl("/ln/search?q=test")).toBe("/ln/search?q=test");
+  });
+
+  it("builds share URLs from current origin", () => {
+    expect(webAdapter.resolveShareUrl("/podcast/abc")).toContain("/podcast/abc");
+  });
+});

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -1,12 +1,26 @@
 import serviceWorker from "../serviceworker";
 import type { PlatformAdapter } from "./types";
 
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const resolveWithCurrentOrigin = (path: string) => {
+  if (isAbsoluteUrl(path) || typeof window === "undefined" || !window.location) {
+    return path;
+  }
+
+  return `${window.location.origin}${withLeadingSlash(path)}`;
+};
+
 const webAdapter: PlatformAdapter = {
   runtime: "web",
   isDesktop: false,
   registerServiceWorker: () => {
     serviceWorker();
   },
+  resolveBackendUrl: (path: string) => path,
+  resolveShareUrl: resolveWithCurrentOrigin,
 };
 
 export default webAdapter;

--- a/src/podcast/Discovery/PodcastSearcher.ts
+++ b/src/podcast/Discovery/PodcastSearcher.ts
@@ -1,3 +1,5 @@
+import platform from "../../platform";
+
 export interface PodcastSearchResponse {
   results?: Array<Record<string, any>>;
   [key: string]: any;
@@ -36,17 +38,17 @@ export default class PodcastSearcher {
     this.currentRequest = new AbortController();
     const { signal } = this.currentRequest;
     return new Promise((accept, reject) =>
-      fetch(`/ln/search?type=podcast&q=${encodeURIComponent(term)}`, { signal })
+      fetch(platform.resolveBackendUrl(`/ln/search?type=podcast&q=${encodeURIComponent(term)}`), { signal })
         .then((result) => (result.ok && result.json().then(accept).catch(reject)) || reject(result))
         .catch(reject)
     );
   }
 
   listennotes(term: string): Promise<PodcastSearchResponse> {
-    return this.querySearch(`/ln/typeahead?q=${encodeURIComponent(term)}&show_podcasts=1`);
+    return this.querySearch(platform.resolveBackendUrl(`/ln/typeahead?q=${encodeURIComponent(term)}&show_podcasts=1`));
   }
 
   apple(term: string): Promise<PodcastSearchResponse> {
-    return this.querySearch(`/apple/search?term=${encodeURIComponent(term)}`);
+    return this.querySearch(platform.resolveBackendUrl(`/apple/search?term=${encodeURIComponent(term)}`));
   }
 }

--- a/src/podcast/Discovery/engine.ts
+++ b/src/podcast/Discovery/engine.ts
@@ -1,6 +1,7 @@
 import PodcastSearcher, { PodcastSearchResponse } from "./PodcastSearcher";
 import { appleCacheKey, getBrowserCached, setBrowserCached } from "./appleBrowserCache";
 import { bestPodcastsCacheKey, getCachedBestPodcasts, setCachedBestPodcasts } from "./popularCache";
+import platform from "../../platform";
 
 export interface PodcastSearchResult {
   title: string;
@@ -107,7 +108,7 @@ export const getPopularPodcasts = async function (query: number | null = null): 
     if (cached) return cached;
 
     try {
-      const resp = await fetch(`/apple/rss/${storefront}/podcasts/top/${limit}/podcasts.json`);
+      const resp = await fetch(platform.resolveBackendUrl(`/apple/rss/${storefront}/podcasts/top/${limit}/podcasts.json`));
       if (!resp.ok) throw new Error(`Apple top failed: ${resp.status}`);
       const data = await resp.json();
       const results = (data && data.feed && data.feed.results) || [];
@@ -157,7 +158,7 @@ export const getPopularPodcasts = async function (query: number | null = null): 
 
   const URI = "https://www.listennotes.com/c/r/";
   try {
-    const resp = await fetch(`/ln/best_podcasts?${params}`);
+    const resp = await fetch(platform.resolveBackendUrl(`/ln/best_podcasts?${params}`));
     if (!resp.ok) throw new Error(`Listen Notes best_podcasts failed: ${resp.status}`);
     const data = await resp.json();
     const { podcasts = [], name } = data;
@@ -201,7 +202,7 @@ export const resolveApplePodcastFeedUrl = async (appleId: string): Promise<strin
   const cached = await getBrowserCached<string>(cacheKey);
   if (cached) return cached;
 
-  const resp = await fetch(`/apple/lookup?id=${encodeURIComponent(id)}`);
+  const resp = await fetch(platform.resolveBackendUrl(`/apple/lookup?id=${encodeURIComponent(id)}`));
   if (!resp.ok) return null;
   const data = await resp.json();
   const result = (data && data.results && data.results[0]) || null;
@@ -238,7 +239,7 @@ export const getApplePodcastGenres = async (): Promise<PodcastGenre[]> => {
   const cached = await getBrowserCached<PodcastGenre[]>(cacheKey);
   if (cached) return cached;
 
-  const resp = await fetch(`/apple/genres?id=26`);
+  const resp = await fetch(platform.resolveBackendUrl("/apple/genres?id=26"));
   if (!resp.ok) return [];
   const data = await resp.json();
 

--- a/src/podcast/Discovery/index.tsx
+++ b/src/podcast/Discovery/index.tsx
@@ -19,6 +19,7 @@ import Search from "./Search";
 import Geners from "./Geners";
 import Loading from "../../core/Loading";
 import HeroCarousel from "./HeroCarousel";
+import platform from "../../platform";
 
 import {
   getPopularPodcasts,
@@ -44,7 +45,7 @@ const Header: React.FC = () => (
 );
 
 const getFinalURL = async (url: string): Promise<string> => {
-  const URL = `${window.location.origin}/api/findFinal/?term=${encodeURIComponent(url)}`;
+  const URL = platform.resolveBackendUrl(`/api/findFinal/?term=${encodeURIComponent(url)}`);
   try {
     const data = await fetch(URL);
     const result = await data.json();

--- a/src/podcast/PodcastView/PodcastHeader.tsx
+++ b/src/podcast/PodcastView/PodcastHeader.tsx
@@ -27,6 +27,7 @@ import { clearText } from "./EpisodeList";
 import { Consumer } from "../../App";
 import { useHistory } from "react-router-dom";
 import { buildThemeFromPalette, toRGBA } from "../../core/podcastPalette";
+import platform from "../../platform";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 const prod = DEBUG ? '' : ''
@@ -174,7 +175,7 @@ function PodcastHeader(props) {
                           onClick={share(
                             "Phonograph",
                             state.title,
-                            `${document.location.origin}/podcast/${makeMeAHash(state.domain)}`
+                            platform.resolveShareUrl(`/podcast/${makeMeAHash(state.domain)}`)
                           )}
                         >
                           <ShareIcon />

--- a/src/serviceworker/worker.ts
+++ b/src/serviceworker/worker.ts
@@ -2,14 +2,44 @@ import PodcastEngine from "podcastsuite";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
+const DEFAULT_DESKTOP_API_ORIGIN = "https://phonograph.app";
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const resolveDesktopBackendOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_DESKTOP_API_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  return DEFAULT_DESKTOP_API_ORIGIN;
+};
+
+const resolveBackendUrl = (path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  const normalizedPath = withLeadingSlash(path);
+  if (location.protocol === "tauri:") {
+    return `${resolveDesktopBackendOrigin()}${normalizedPath}`;
+  }
+
+  return `//${location.host}${normalizedPath}`;
+};
+
 const proxy = DEBUG
   ? {
-      "https:": `//${location.host}/rss-full/?term=https://`,
-      "http:": `//${location.host}/rss-full/?term=http://`,
+      "https:": resolveBackendUrl("/rss-full/?term=https://"),
+      "http:": resolveBackendUrl("/rss-full/?term=http://"),
     }
   : {
-      "https:": `//${location.host}/rss-full/https://`,
-      "http:": `//${location.host}/rss-full/http://`,
+      "https:": resolveBackendUrl("/rss-full/https://"),
+      "http:": resolveBackendUrl("/rss-full/http://"),
     };
 
 const getPodcastEngine = (shouldInit = false) =>

--- a/src/types/vite-env.d.ts
+++ b/src/types/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION?: string;
   readonly VITE_COMMIT_REF?: string;
   readonly VITE_DEPLOY_ID?: string;
+  readonly VITE_DESKTOP_API_ORIGIN?: string;
+  readonly VITE_PUBLIC_WEB_ORIGIN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Issue context
Desktop support exists, but Tauri runtime URL handling and desktop version metadata can drift from the web package version. This causes release fragility (stale Tauri/Cargo version metadata) and inconsistent desktop/runtime behavior.

## What changed
- Hardened platform adapter behavior for desktop runtime URL resolution and environment-specific web origin handling.
- Updated discovery/player/share-link flows to use platform-level URL resolution consistently.
- Added desktop parity tracking document: `docs/desktop-parity.md`.
- Expanded `scripts/sync-tauri-version.mjs` to synchronize `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
- Updated `scripts/bump-version.mjs` to keep desktop manifest/version files in sync during bumps.
- Added `scripts/validate-desktop-signing-env.mjs` and wired a CI desktop build command.
- Updated desktop scripts in `package.json` to sync versions before `desktop:dev`/`desktop:build`, plus `desktop:build:ci`.
- Hardened version bump workflow to stage Tauri/Cargo artifacts and emit summary output.

## Validation
- `yarn test src/platform/index.test.ts src/platform/web.test.ts src/platform/tauri.test.ts`
- `yarn typecheck`
- `yarn lint:errors`
- `yarn test`
- `yarn desktop:sync-version`
- `node scripts/validate-desktop-signing-env.mjs` (expected local skip when not on release ref)

## Rollout notes
- No runtime migration required.
- Desktop release automation now expects synchronized Tauri/Cargo versions from scripts.
- On release tags, CI enforces desktop signing env validation via `desktop:build:ci`.
