### PR TITLE
feat(desktop): harden Tauri native OPML integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Build desktop bundles:
 yarn desktop:build
 ```
 
+Desktop builds now include native OPML import/export dialogs backed by Tauri's
+`dialog` + `fs` plugins with scoped permissions to OPML/XML files in the user home directory.
+
 ### Desktop release + download links
 
 - Pushing a semver tag (for example `v1.3.24`) triggers `.github/workflows/desktop-release-macos.yml`.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2293,11 +2293,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "phonograph_desktop"
-version = "0.1.0"
+name = "phonograph"
+version = "1.3.24"
 dependencies = [
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
 ]
 
 [[package]]
@@ -2670,6 +2672,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3372,6 +3398,63 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "phonograph_desktop"
-version = "0.1.0"
+name = "phonograph"
+version = "1.3.24"
 description = "Phonograph desktop shell"
 authors = ["Phonograph Team"]
 edition = "2021"
@@ -10,6 +10,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2.6.0"
+tauri-plugin-fs = "2.4.5"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,43 @@
   "identifier": "default",
   "description": "Default capabilities for the main desktop window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "dialog:allow-open",
+    "dialog:allow-save",
+    {
+      "identifier": "fs:allow-read-text-file",
+      "allow": [
+        {
+          "path": "$HOME/**/*.opml"
+        },
+        {
+          "path": "$HOME/**/*.xml"
+        },
+        {
+          "path": "$HOME/**/*.OPML"
+        },
+        {
+          "path": "$HOME/**/*.XML"
+        }
+      ]
+    },
+    {
+      "identifier": "fs:allow-write-text-file",
+      "allow": [
+        {
+          "path": "$HOME/**/*.opml"
+        },
+        {
+          "path": "$HOME/**/*.xml"
+        },
+        {
+          "path": "$HOME/**/*.OPML"
+        },
+        {
+          "path": "$HOME/**/*.XML"
+        }
+      ]
+    }
+  ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
 
 fn main() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_fs::init())
     .run(tauri::generate_context!())
     .expect("error while running phonograph desktop shell");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phonograph",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "identifier": "app.phonograph.desktop",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -21,7 +21,7 @@
     ]
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
     "icon": [
       "../public/android-chrome-512x512.png",

--- a/src/platform/opmlDialogs.test.ts
+++ b/src/platform/opmlDialogs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "./opmlDialogs";
+import { exportOpmlWithNativeDialog, importOpmlFromNativeDialog } from "./opmlDialogs";
 
 const setWindow = (value: any) => {
   Object.defineProperty(globalThis, "window", {
@@ -17,8 +17,7 @@ describe("opmlDialogs", () => {
   it("reports unsupported when native APIs are absent", async () => {
     setWindow(undefined);
 
-    expect(hasNativeOpmlDialogs()).toBe(false);
-    await expect(importOpmlFromNativeDialog()).resolves.toBeNull();
+    await expect(importOpmlFromNativeDialog()).resolves.toEqual({ status: "unsupported" });
     await expect(exportOpmlWithNativeDialog("<opml />", "subs.opml")).resolves.toBe("unsupported");
   });
 
@@ -36,6 +35,7 @@ describe("opmlDialogs", () => {
     const result = await importOpmlFromNativeDialog();
 
     expect(result).toEqual({
+      status: "selected",
       text: "<opml>hello</opml>",
       fileName: "subscriptions.opml",
     });
@@ -72,4 +72,3 @@ describe("opmlDialogs", () => {
     await expect(exportOpmlWithNativeDialog("<opml>content</opml>", "subs.opml")).resolves.toBe("cancelled");
   });
 });
-

--- a/src/platform/opmlDialogs.ts
+++ b/src/platform/opmlDialogs.ts
@@ -92,14 +92,17 @@ const writeTextFile = async (fsApi: TauriFsApi, path: string, contents: string) 
   throw new Error("Native file-write API is unavailable.");
 };
 
-export const hasNativeOpmlDialogs = () => Boolean(getTauriDialogApi() && getTauriFsApi());
+export type NativeOpmlImportStatus =
+  | { status: "selected"; text: string; fileName: string }
+  | { status: "cancelled" }
+  | { status: "unsupported" };
 
-export const importOpmlFromNativeDialog = async (): Promise<{ text: string; fileName: string } | null> => {
+export const importOpmlFromNativeDialog = async (): Promise<NativeOpmlImportStatus> => {
   const dialogApi = getTauriDialogApi();
   const fsApi = getTauriFsApi();
 
   if (!dialogApi || !fsApi?.readTextFile) {
-    return null;
+    return { status: "unsupported" };
   }
 
   const selectedPath = await dialogApi.open({
@@ -110,12 +113,13 @@ export const importOpmlFromNativeDialog = async (): Promise<{ text: string; file
   });
 
   if (!selectedPath || Array.isArray(selectedPath)) {
-    return null;
+    return { status: "cancelled" };
   }
 
   const text = await fsApi.readTextFile(selectedPath);
 
   return {
+    status: "selected",
     text,
     fileName: getFilenameFromPath(selectedPath),
   };
@@ -147,4 +151,3 @@ export const exportOpmlWithNativeDialog = async (
   await writeTextFile(fsApi, selectedPath, opmlContents);
   return "saved";
 };
-

--- a/src/podcast/Settings.tsx
+++ b/src/podcast/Settings.tsx
@@ -35,7 +35,7 @@ import UploadFileIcon from "@mui/icons-material/UploadFile";
 import DownloadIcon from "@mui/icons-material/Download";
 
 import { initializeLibrary } from "../engine";
-import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
+import { exportOpmlWithNativeDialog, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
 import { buildOpml, parseOpml } from "./opml";
 import { importFeeds } from "./opmlImporter";
 import { DOWNLOADVIEW } from "../constants";
@@ -228,18 +228,23 @@ const Settings: React.FC = () => {
   const openFilePicker = async () => {
     if (isImporting) return;
 
-    if (hasNativeOpmlDialogs()) {
-      try {
-        const selected = await importOpmlFromNativeDialog();
-        if (!selected) return;
+    try {
+      const selected = await importOpmlFromNativeDialog();
+
+      if (selected.status === "selected") {
         await importOpmlText(selected.text);
-      } catch (err: any) {
-        setNotice({
-          open: true,
-          message: err?.message || intl.formatMessage({ id: "settings.importFailed", defaultMessage: "Failed to import OPML." }),
-          severity: "error",
-        });
+        return;
       }
+
+      if (selected.status === "cancelled") {
+        return;
+      }
+    } catch (err: any) {
+      setNotice({
+        open: true,
+        message: err?.message || intl.formatMessage({ id: "settings.importFailed", defaultMessage: "Failed to import OPML." }),
+        severity: "error",
+      });
       return;
     }
 


### PR DESCRIPTION
## Context
Desktop Tauri hardening for production OPML native flows.

## Changes
- Register Tauri dialog/fs plugins in desktop host
- Add scoped OPML/XML read-write capabilities under $HOME
- Align desktop crate identity/version and enable bundling by default
- Return explicit import statuses (selected/cancelled/unsupported)
- Update Settings import path to native-first with unsupported fallback
- Update OPML platform tests and README notes

## Validation
- yarn test src/platform/opmlDialogs.test.ts src/platform/index.test.ts src/platform/tauri.test.ts
- yarn typecheck
- yarn quality
- cargo check --manifest-path src-tauri/Cargo.toml --locked
- yarn desktop:build -- --no-bundle

## Rollout
No env changes required; desktop bundle output is now active by default.