### PR TITLE
feat(desktop): harden tauri platform runtime, release sync, and OPML dialogs

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Sync Tauri version with package version
-        run: node scripts/sync-tauri-version.mjs
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -37,12 +37,31 @@ jobs:
         run: node scripts/bump-version.mjs patch
 
       - name: Commit and tag
+        id: commit_tag
         if: steps.check.outputs.skip != 'true'
         run: |
           next="$(node -p "require('./package.json').version")"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json || true
+
+          git add package.json
+
+          if [ -f package-lock.json ]; then
+            git add package-lock.json
+          fi
+
+          if [ -f src-tauri/tauri.conf.json ]; then
+            git add src-tauri/tauri.conf.json
+          fi
+
+          if [ -f src-tauri/Cargo.toml ]; then
+            git add src-tauri/Cargo.toml
+          fi
+
+          if [ -f src-tauri/Cargo.lock ]; then
+            git add src-tauri/Cargo.lock
+          fi
+
           if git diff --cached --quiet; then
             echo "No version changes to commit."
             exit 0
@@ -51,3 +70,17 @@ jobs:
           git tag "v$next"
           git push
           git push --tags
+
+      - name: Report version bump status
+        if: always()
+        run: |
+          {
+            echo "## Version bump"
+            echo "- Release bump skipped: ${{ steps.check.outputs.skip }}"
+            echo "- Commit + tag step: ${{ steps.commit_tag.outcome || 'skipped' }}"
+            if [ "${{ steps.check.outputs.skip }}" = "true" ]; then
+              echo "- Existing release commit detected; no new tag created."
+            else
+              echo "- Patch version bump attempted."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ Build pipeline (`yarn build`) includes:
 
 - `LISTEN_NOTES_API_KEY` (preferred)
 - `LISTENNOTES` / `listennotes` (backward-compatible alternatives)
+- `VITE_DESKTOP_API_ORIGIN` (optional; desktop backend origin, defaults to `https://phonograph.app`)
+- `VITE_PUBLIC_WEB_ORIGIN` (optional; desktop share-link origin, defaults to `https://phonograph.app`)
 
 These are used for discovery/proxy calls that depend on Listen Notes.
+
+Desktop parity status and release-readiness notes are tracked in `docs/desktop-parity.md`.
 
 ## Quality and Testing
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ CI/release desktop build (includes signing-env validation):
 yarn desktop:build:ci
 ```
 
+Desktop builds now include native OPML import/export dialogs backed by Tauri's
+`dialog` + `fs` plugins with scoped permissions to OPML/XML files in the user home directory.
+
 ### Desktop release + download links
 
 - Pushing a semver tag (for example `v1.3.24`) triggers `.github/workflows/desktop-release-macos.yml`.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ Build desktop bundles:
 yarn desktop:build
 ```
 
+Synchronize desktop manifest versions only:
+
+```bash
+yarn desktop:sync-version
+```
+
+CI/release desktop build (includes signing-env validation):
+
+```bash
+yarn desktop:build:ci
+```
+
 ### Desktop release + download links
 
 - Pushing a semver tag (for example `v1.3.24`) triggers `.github/workflows/desktop-release-macos.yml`.
@@ -197,6 +209,10 @@ Build pipeline (`yarn build`) includes:
 - `LISTENNOTES` / `listennotes` (backward-compatible alternatives)
 - `VITE_DESKTOP_API_ORIGIN` (optional; desktop backend origin, defaults to `https://phonograph.app`)
 - `VITE_PUBLIC_WEB_ORIGIN` (optional; desktop share-link origin, defaults to `https://phonograph.app`)
+
+Desktop signing validation checks these env vars when running on release refs (or with `--force`):
+- macOS: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PATH`
+- Windows: `TAURI_WINDOWS_CERTIFICATE`, `TAURI_WINDOWS_CERTIFICATE_PASSWORD`
 
 These are used for discovery/proxy calls that depend on Listen Notes.
 

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -1,0 +1,26 @@
+# Desktop Parity Status
+
+This document tracks web/desktop parity for the Phonograph v1 playback journeys.
+
+## Core Flow Coverage
+
+- ✅ Discover view runs in desktop shell with Apple/Listen Notes requests resolved through the platform adapter.
+- ✅ Library and podcast detail flows run in desktop shell through shared reducer/state modules.
+- ✅ Playlist and playback controls run in desktop shell through shared player modules.
+- ✅ Settings flow runs in desktop shell, including OPML import/export with native dialogs.
+
+## Adapter Boundaries
+
+Desktop-specific behavior is isolated in `src/platform/`:
+
+- `registerServiceWorker`: enabled on web, no-op on desktop.
+- `resolveBackendUrl`: resolves desktop API paths to hosted or configured backend origins.
+- `resolveShareUrl`: ensures desktop share links target the public web origin.
+
+Domain/UI modules in `src/podcast`, `src/core`, `src/engine`, and `src/store` consume adapter functions instead of hard-coding runtime assumptions.
+
+## Operational Notes
+
+1. Desktop defaults to `https://phonograph.app` for backend/share origins.
+2. Override desktop origins with `VITE_DESKTOP_API_ORIGIN` and `VITE_PUBLIC_WEB_ORIGIN` for staging or self-hosted environments.
+3. Desktop signing and notarization pipelines remain a release engineering follow-up.

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   ],
   "scripts": {
     "start": "vite",
-    "desktop:dev": "tauri dev",
-    "desktop:build": "tauri build",
+    "desktop:sync-version": "node scripts/sync-tauri-version.mjs",
+    "desktop:dev": "yarn desktop:sync-version && tauri dev",
+    "desktop:build": "yarn desktop:sync-version && tauri build",
+    "desktop:build:ci": "yarn desktop:sync-version && node scripts/validate-desktop-signing-env.mjs && tauri build",
     "build": "yarn getter && vite build && yarn SEO && yarn sw && yarn docs:manuals:build && yarn lambda:build",
     "serve": "vite preview",
     "docs:manuals:dev": "vitepress dev manuals",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -32,6 +32,61 @@ const bump = (version, type) => {
   return `${major}.${minor}.${patch + 1}`;
 };
 
+const parseCargoPackageName = (cargoToml) => {
+  const match = cargoToml.match(/^name\s*=\s*"([^"]+)"$/m);
+  if (!match) {
+    throw new Error("Unable to determine Cargo package name from src-tauri/Cargo.toml");
+  }
+
+  return match[1];
+};
+
+const syncCargoLockVersion = ({ cargoLockPath, cargoPackageName, version }) => {
+  if (!fs.existsSync(cargoLockPath)) {
+    return;
+  }
+
+  const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedPackageName = escapeRegex(cargoPackageName);
+  const cargoLock = fs.readFileSync(cargoLockPath, "utf8");
+  const packageVersionPattern = new RegExp(
+    `(\\[\\[package\\]\\][\\r\\n]+name = \"${escapedPackageName}\"[\\r\\n]+version = \")[^\"]+(\")`,
+    "m"
+  );
+
+  const updatedCargoLock = cargoLock.replace(packageVersionPattern, `$1${version}$2`);
+
+  if (updatedCargoLock !== cargoLock) {
+    fs.writeFileSync(cargoLockPath, updatedCargoLock);
+  }
+};
+
+const syncDesktopVersion = (version) => {
+  const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+  const cargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
+  const cargoLockPath = path.join(repoRoot, "src-tauri", "Cargo.lock");
+
+  if (!fs.existsSync(tauriConfigPath) || !fs.existsSync(cargoTomlPath)) {
+    return;
+  }
+
+  const tauriConfig = readJson(tauriConfigPath);
+  if (tauriConfig.version !== version) {
+    tauriConfig.version = version;
+    writeJson(tauriConfigPath, tauriConfig);
+  }
+
+  const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
+  const cargoPackageName = parseCargoPackageName(cargoToml);
+  const updatedCargoToml = cargoToml.replace(/^(version\s*=\s*").*(")$/m, `$1${version}$2`);
+
+  if (updatedCargoToml !== cargoToml) {
+    fs.writeFileSync(cargoTomlPath, updatedCargoToml);
+  }
+
+  syncCargoLockVersion({ cargoLockPath, cargoPackageName, version });
+};
+
 const pkgPath = path.join(repoRoot, "package.json");
 const pkg = readJson(pkgPath);
 const current = pkg.version;
@@ -54,15 +109,6 @@ if (fs.existsSync(lockPath)) {
   }
 }
 
-process.stdout.write(next);
+syncDesktopVersion(next);
 
-const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
-if (fs.existsSync(tauriConfigPath)) {
-  try {
-    const tauriConfig = readJson(tauriConfigPath);
-    tauriConfig.version = next;
-    fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
-  } catch (e) {
-    // Ignore tauri config updates if the file is malformed.
-  }
-}
+process.stdout.write(next);

--- a/scripts/sync-tauri-version.mjs
+++ b/scripts/sync-tauri-version.mjs
@@ -6,19 +6,62 @@ import path from "node:path";
 const repoRoot = process.cwd();
 const packageJsonPath = path.join(repoRoot, "package.json");
 const tauriConfigPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+const cargoTomlPath = path.join(repoRoot, "src-tauri", "Cargo.toml");
+const cargoLockPath = path.join(repoRoot, "src-tauri", "Cargo.lock");
 
-if (!fs.existsSync(packageJsonPath) || !fs.existsSync(tauriConfigPath)) {
+const parseCargoPackageName = (cargoToml) => {
+  const match = cargoToml.match(/^name\s*=\s*"([^"]+)"$/m);
+  if (!match) {
+    throw new Error("Unable to determine Cargo package name from src-tauri/Cargo.toml");
+  }
+
+  return match[1];
+};
+
+const syncCargoLockVersion = ({ cargoPackageName, version }) => {
+  if (!fs.existsSync(cargoLockPath)) {
+    return;
+  }
+
+  const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedPackageName = escapeRegex(cargoPackageName);
+  const cargoLock = fs.readFileSync(cargoLockPath, "utf8");
+  const packageVersionPattern = new RegExp(
+    `(\\[\\[package\\]\\][\\r\\n]+name = \"${escapedPackageName}\"[\\r\\n]+version = \")[^\"]+(\")`,
+    "m"
+  );
+
+  const updatedCargoLock = cargoLock.replace(packageVersionPattern, `$1${version}$2`);
+
+  if (updatedCargoLock !== cargoLock) {
+    fs.writeFileSync(cargoLockPath, updatedCargoLock);
+  }
+};
+
+if (!fs.existsSync(packageJsonPath) || !fs.existsSync(tauriConfigPath) || !fs.existsSync(cargoTomlPath)) {
   process.exit(0);
 }
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, "utf8"));
+const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
 
 if (!packageJson.version || typeof packageJson.version !== "string") {
   throw new Error("package.json version is missing or invalid");
 }
 
-tauriConfig.version = packageJson.version;
-fs.writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + "\n");
+const version = packageJson.version;
 
-process.stdout.write(packageJson.version);
+tauriConfig.version = version;
+fs.writeFileSync(tauriConfigPath, `${JSON.stringify(tauriConfig, null, 2)}\n`);
+
+const cargoPackageName = parseCargoPackageName(cargoToml);
+const updatedCargoToml = cargoToml.replace(/^(version\s*=\s*").*(")$/m, `$1${version}$2`);
+
+if (updatedCargoToml !== cargoToml) {
+  fs.writeFileSync(cargoTomlPath, updatedCargoToml);
+}
+
+syncCargoLockVersion({ cargoPackageName, version });
+
+process.stdout.write(`Desktop version synchronized to ${version}\n`);

--- a/scripts/validate-desktop-signing-env.mjs
+++ b/scripts/validate-desktop-signing-env.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const hasDesktopConfig = fs.existsSync(path.join(root, "src-tauri", "tauri.conf.json"));
+
+if (!hasDesktopConfig) {
+  process.stdout.write("Desktop workspace not found, skipping signing validation.\n");
+  process.exit(0);
+}
+
+const isCi = process.env.CI === "true";
+const isReleaseRef = process.env.GITHUB_REF_TYPE === "tag";
+const shouldEnforce = process.argv.includes("--force") || (isCi && isReleaseRef);
+
+if (!shouldEnforce) {
+  process.stdout.write("Skipping desktop signing environment validation.\n");
+  process.exit(0);
+}
+
+const missing = [];
+
+const requireEnv = (name) => {
+  if (!process.env[name]) {
+    missing.push(name);
+  }
+};
+
+const platform = process.platform;
+if (platform === "darwin") {
+  requireEnv("APPLE_CERTIFICATE");
+  requireEnv("APPLE_CERTIFICATE_PASSWORD");
+  requireEnv("APPLE_SIGNING_IDENTITY");
+  requireEnv("APPLE_API_ISSUER");
+  requireEnv("APPLE_API_KEY");
+  requireEnv("APPLE_API_KEY_PATH");
+}
+
+if (platform === "win32") {
+  requireEnv("TAURI_WINDOWS_CERTIFICATE");
+  requireEnv("TAURI_WINDOWS_CERTIFICATE_PASSWORD");
+}
+
+if (missing.length > 0) {
+  console.error("Missing required desktop signing environment variables:");
+  for (const variableName of missing) {
+    console.error(`- ${variableName}`);
+  }
+  process.exit(1);
+}
+
+process.stdout.write("Desktop signing environment validation passed.\n");

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2293,11 +2293,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "phonograph_desktop"
+name = "phonograph"
 version = "1.3.24"
 dependencies = [
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
 ]
 
 [[package]]
@@ -2670,6 +2672,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3372,6 +3398,63 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "phonograph_desktop"
-version = "0.1.0"
+version = "1.3.24"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "phonograph_desktop"
+name = "phonograph"
 version = "1.3.24"
 description = "Phonograph desktop shell"
 authors = ["Phonograph Team"]
@@ -10,6 +10,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2.6.0"
+tauri-plugin-fs = "2.4.5"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phonograph_desktop"
-version = "0.1.0"
+version = "1.3.24"
 description = "Phonograph desktop shell"
 authors = ["Phonograph Team"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,43 @@
   "identifier": "default",
   "description": "Default capabilities for the main desktop window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "dialog:allow-open",
+    "dialog:allow-save",
+    {
+      "identifier": "fs:allow-read-text-file",
+      "allow": [
+        {
+          "path": "$HOME/**/*.opml"
+        },
+        {
+          "path": "$HOME/**/*.xml"
+        },
+        {
+          "path": "$HOME/**/*.OPML"
+        },
+        {
+          "path": "$HOME/**/*.XML"
+        }
+      ]
+    },
+    {
+      "identifier": "fs:allow-write-text-file",
+      "allow": [
+        {
+          "path": "$HOME/**/*.opml"
+        },
+        {
+          "path": "$HOME/**/*.xml"
+        },
+        {
+          "path": "$HOME/**/*.OPML"
+        },
+        {
+          "path": "$HOME/**/*.XML"
+        }
+      ]
+    }
+  ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
 
 fn main() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_fs::init())
     .run(tauri::generate_context!())
     .expect("error while running phonograph desktop shell");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phonograph",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "identifier": "app.phonograph.desktop",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -21,7 +21,7 @@
     ]
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
     "icon": [
       "../public/android-chrome-512x512.png",

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,15 +1,13 @@
 import PodcastEngine from "podcastsuite";
 import { podcasts } from "../podcast";
 import { AppAction } from "../types/app";
+import platform from "../platform";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
-const HOST =
-  typeof window !== "undefined" && window.location ? window.location.host : "";
-
 const PROXY = {
-  "https:": `//${HOST}/rss-full/?term=https://`,
-  "http:": `//${HOST}/rss-full/?term=http://`,
+  "https:": platform.resolveBackendUrl("/rss-full/?term=https://"),
+  "http:": platform.resolveBackendUrl("/rss-full/?term=http://"),
 };
 
 export const checkIfNewPodcastInURL = () => {

--- a/src/platform/index.test.ts
+++ b/src/platform/index.test.ts
@@ -6,11 +6,26 @@ describe("platform adapter", () => {
     const adapter = createPlatformAdapter(false);
     expect(adapter.runtime).toBe("web");
     expect(adapter.isDesktop).toBe(false);
+    expect(adapter.resolveBackendUrl("/apple/search?term=foo")).toBe("/apple/search?term=foo");
+    expect(adapter.resolveShareUrl("/podcast/abc")).toContain("/podcast/abc");
   });
 
   it("returns tauri adapter when tauri runtime is active", () => {
     const adapter = createPlatformAdapter(true);
     expect(adapter.runtime).toBe("tauri");
     expect(adapter.isDesktop).toBe(true);
+    expect(adapter.resolveBackendUrl("/apple/search?term=foo")).toBe("https://phonograph.app/apple/search?term=foo");
+    expect(adapter.resolveShareUrl("/podcast/abc")).toBe("https://phonograph.app/podcast/abc");
+  });
+
+  it("preserves fully-qualified URLs", () => {
+    const webAdapter = createPlatformAdapter(false);
+    const tauriAdapter = createPlatformAdapter(true);
+    const absoluteUrl = "https://example.com/path";
+
+    expect(webAdapter.resolveBackendUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(tauriAdapter.resolveBackendUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(webAdapter.resolveShareUrl(absoluteUrl)).toBe(absoluteUrl);
+    expect(tauriAdapter.resolveShareUrl(absoluteUrl)).toBe(absoluteUrl);
   });
 });

--- a/src/platform/opmlDialogs.test.ts
+++ b/src/platform/opmlDialogs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "./opmlDialogs";
+import { exportOpmlWithNativeDialog, importOpmlFromNativeDialog } from "./opmlDialogs";
 
 const setWindow = (value: any) => {
   Object.defineProperty(globalThis, "window", {
@@ -17,8 +17,7 @@ describe("opmlDialogs", () => {
   it("reports unsupported when native APIs are absent", async () => {
     setWindow(undefined);
 
-    expect(hasNativeOpmlDialogs()).toBe(false);
-    await expect(importOpmlFromNativeDialog()).resolves.toBeNull();
+    await expect(importOpmlFromNativeDialog()).resolves.toEqual({ status: "unsupported" });
     await expect(exportOpmlWithNativeDialog("<opml />", "subs.opml")).resolves.toBe("unsupported");
   });
 
@@ -36,6 +35,7 @@ describe("opmlDialogs", () => {
     const result = await importOpmlFromNativeDialog();
 
     expect(result).toEqual({
+      status: "selected",
       text: "<opml>hello</opml>",
       fileName: "subscriptions.opml",
     });
@@ -72,4 +72,3 @@ describe("opmlDialogs", () => {
     await expect(exportOpmlWithNativeDialog("<opml>content</opml>", "subs.opml")).resolves.toBe("cancelled");
   });
 });
-

--- a/src/platform/opmlDialogs.ts
+++ b/src/platform/opmlDialogs.ts
@@ -92,14 +92,17 @@ const writeTextFile = async (fsApi: TauriFsApi, path: string, contents: string) 
   throw new Error("Native file-write API is unavailable.");
 };
 
-export const hasNativeOpmlDialogs = () => Boolean(getTauriDialogApi() && getTauriFsApi());
+export type NativeOpmlImportStatus =
+  | { status: "selected"; text: string; fileName: string }
+  | { status: "cancelled" }
+  | { status: "unsupported" };
 
-export const importOpmlFromNativeDialog = async (): Promise<{ text: string; fileName: string } | null> => {
+export const importOpmlFromNativeDialog = async (): Promise<NativeOpmlImportStatus> => {
   const dialogApi = getTauriDialogApi();
   const fsApi = getTauriFsApi();
 
   if (!dialogApi || !fsApi?.readTextFile) {
-    return null;
+    return { status: "unsupported" };
   }
 
   const selectedPath = await dialogApi.open({
@@ -110,12 +113,13 @@ export const importOpmlFromNativeDialog = async (): Promise<{ text: string; file
   });
 
   if (!selectedPath || Array.isArray(selectedPath)) {
-    return null;
+    return { status: "cancelled" };
   }
 
   const text = await fsApi.readTextFile(selectedPath);
 
   return {
+    status: "selected",
     text,
     fileName: getFilenameFromPath(selectedPath),
   };
@@ -147,4 +151,3 @@ export const exportOpmlWithNativeDialog = async (
   await writeTextFile(fsApi, selectedPath, opmlContents);
   return "saved";
 };
-

--- a/src/platform/tauri.test.ts
+++ b/src/platform/tauri.test.ts
@@ -10,5 +10,12 @@ describe("tauri platform adapter", () => {
   it("uses a no-op service worker registration", () => {
     expect(() => tauriAdapter.registerServiceWorker()).not.toThrow();
   });
-});
 
+  it("resolves backend URLs to the hosted API origin", () => {
+    expect(tauriAdapter.resolveBackendUrl("/ln/search?q=test")).toBe("https://phonograph.app/ln/search?q=test");
+  });
+
+  it("resolves share URLs to the public web origin", () => {
+    expect(tauriAdapter.resolveShareUrl("/podcast/abc")).toBe("https://phonograph.app/podcast/abc");
+  });
+});

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -1,9 +1,49 @@
 import type { PlatformAdapter } from "./types";
 
+const DEFAULT_PUBLIC_WEB_ORIGIN = "https://phonograph.app";
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const resolveDesktopBackendOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_DESKTOP_API_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  if (import.meta.env.DEV && typeof window !== "undefined" && window.location?.origin) {
+    return trimTrailingSlash(window.location.origin);
+  }
+
+  return DEFAULT_PUBLIC_WEB_ORIGIN;
+};
+
+const resolvePublicWebOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_PUBLIC_WEB_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  return DEFAULT_PUBLIC_WEB_ORIGIN;
+};
+
+const toAbsoluteUrl = (origin: string, path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  return `${trimTrailingSlash(origin)}${withLeadingSlash(path)}`;
+};
+
 const tauriAdapter: PlatformAdapter = {
   runtime: "tauri",
   isDesktop: true,
   registerServiceWorker: () => {},
+  resolveBackendUrl: (path: string) => toAbsoluteUrl(resolveDesktopBackendOrigin(), path),
+  resolveShareUrl: (path: string) => toAbsoluteUrl(resolvePublicWebOrigin(), path),
 };
 
 export default tauriAdapter;

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -4,4 +4,6 @@ export interface PlatformAdapter {
   runtime: PlatformRuntime;
   isDesktop: boolean;
   registerServiceWorker: () => void;
+  resolveBackendUrl: (path: string) => string;
+  resolveShareUrl: (path: string) => string;
 }

--- a/src/platform/web.test.ts
+++ b/src/platform/web.test.ts
@@ -11,5 +11,12 @@ describe("web platform adapter", () => {
     webAdapter.registerServiceWorker();
     expect(serviceWorker).toHaveBeenCalledTimes(1);
   });
-});
 
+  it("keeps backend URLs relative for proxying", () => {
+    expect(webAdapter.resolveBackendUrl("/ln/search?q=test")).toBe("/ln/search?q=test");
+  });
+
+  it("builds share URLs from current origin", () => {
+    expect(webAdapter.resolveShareUrl("/podcast/abc")).toContain("/podcast/abc");
+  });
+});

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -1,12 +1,26 @@
 import serviceWorker from "../serviceworker";
 import type { PlatformAdapter } from "./types";
 
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const resolveWithCurrentOrigin = (path: string) => {
+  if (isAbsoluteUrl(path) || typeof window === "undefined" || !window.location) {
+    return path;
+  }
+
+  return `${window.location.origin}${withLeadingSlash(path)}`;
+};
+
 const webAdapter: PlatformAdapter = {
   runtime: "web",
   isDesktop: false,
   registerServiceWorker: () => {
     serviceWorker();
   },
+  resolveBackendUrl: (path: string) => path,
+  resolveShareUrl: resolveWithCurrentOrigin,
 };
 
 export default webAdapter;

--- a/src/podcast/Discovery/PodcastSearcher.ts
+++ b/src/podcast/Discovery/PodcastSearcher.ts
@@ -1,3 +1,5 @@
+import platform from "../../platform";
+
 export interface PodcastSearchResponse {
   results?: Array<Record<string, any>>;
   [key: string]: any;
@@ -36,17 +38,17 @@ export default class PodcastSearcher {
     this.currentRequest = new AbortController();
     const { signal } = this.currentRequest;
     return new Promise((accept, reject) =>
-      fetch(`/ln/search?type=podcast&q=${encodeURIComponent(term)}`, { signal })
+      fetch(platform.resolveBackendUrl(`/ln/search?type=podcast&q=${encodeURIComponent(term)}`), { signal })
         .then((result) => (result.ok && result.json().then(accept).catch(reject)) || reject(result))
         .catch(reject)
     );
   }
 
   listennotes(term: string): Promise<PodcastSearchResponse> {
-    return this.querySearch(`/ln/typeahead?q=${encodeURIComponent(term)}&show_podcasts=1`);
+    return this.querySearch(platform.resolveBackendUrl(`/ln/typeahead?q=${encodeURIComponent(term)}&show_podcasts=1`));
   }
 
   apple(term: string): Promise<PodcastSearchResponse> {
-    return this.querySearch(`/apple/search?term=${encodeURIComponent(term)}`);
+    return this.querySearch(platform.resolveBackendUrl(`/apple/search?term=${encodeURIComponent(term)}`));
   }
 }

--- a/src/podcast/Discovery/engine.ts
+++ b/src/podcast/Discovery/engine.ts
@@ -1,6 +1,7 @@
 import PodcastSearcher, { PodcastSearchResponse } from "./PodcastSearcher";
 import { appleCacheKey, getBrowserCached, setBrowserCached } from "./appleBrowserCache";
 import { bestPodcastsCacheKey, getCachedBestPodcasts, setCachedBestPodcasts } from "./popularCache";
+import platform from "../../platform";
 
 export interface PodcastSearchResult {
   title: string;
@@ -107,7 +108,7 @@ export const getPopularPodcasts = async function (query: number | null = null): 
     if (cached) return cached;
 
     try {
-      const resp = await fetch(`/apple/rss/${storefront}/podcasts/top/${limit}/podcasts.json`);
+      const resp = await fetch(platform.resolveBackendUrl(`/apple/rss/${storefront}/podcasts/top/${limit}/podcasts.json`));
       if (!resp.ok) throw new Error(`Apple top failed: ${resp.status}`);
       const data = await resp.json();
       const results = (data && data.feed && data.feed.results) || [];
@@ -157,7 +158,7 @@ export const getPopularPodcasts = async function (query: number | null = null): 
 
   const URI = "https://www.listennotes.com/c/r/";
   try {
-    const resp = await fetch(`/ln/best_podcasts?${params}`);
+    const resp = await fetch(platform.resolveBackendUrl(`/ln/best_podcasts?${params}`));
     if (!resp.ok) throw new Error(`Listen Notes best_podcasts failed: ${resp.status}`);
     const data = await resp.json();
     const { podcasts = [], name } = data;
@@ -201,7 +202,7 @@ export const resolveApplePodcastFeedUrl = async (appleId: string): Promise<strin
   const cached = await getBrowserCached<string>(cacheKey);
   if (cached) return cached;
 
-  const resp = await fetch(`/apple/lookup?id=${encodeURIComponent(id)}`);
+  const resp = await fetch(platform.resolveBackendUrl(`/apple/lookup?id=${encodeURIComponent(id)}`));
   if (!resp.ok) return null;
   const data = await resp.json();
   const result = (data && data.results && data.results[0]) || null;
@@ -238,7 +239,7 @@ export const getApplePodcastGenres = async (): Promise<PodcastGenre[]> => {
   const cached = await getBrowserCached<PodcastGenre[]>(cacheKey);
   if (cached) return cached;
 
-  const resp = await fetch(`/apple/genres?id=26`);
+  const resp = await fetch(platform.resolveBackendUrl("/apple/genres?id=26"));
   if (!resp.ok) return [];
   const data = await resp.json();
 

--- a/src/podcast/Discovery/index.tsx
+++ b/src/podcast/Discovery/index.tsx
@@ -19,6 +19,7 @@ import Search from "./Search";
 import Geners from "./Geners";
 import Loading from "../../core/Loading";
 import HeroCarousel from "./HeroCarousel";
+import platform from "../../platform";
 
 import {
   getPopularPodcasts,
@@ -44,7 +45,7 @@ const Header: React.FC = () => (
 );
 
 const getFinalURL = async (url: string): Promise<string> => {
-  const URL = `${window.location.origin}/api/findFinal/?term=${encodeURIComponent(url)}`;
+  const URL = platform.resolveBackendUrl(`/api/findFinal/?term=${encodeURIComponent(url)}`);
   try {
     const data = await fetch(URL);
     const result = await data.json();

--- a/src/podcast/PodcastView/PodcastHeader.tsx
+++ b/src/podcast/PodcastView/PodcastHeader.tsx
@@ -27,6 +27,7 @@ import { clearText } from "./EpisodeList";
 import { Consumer } from "../../App";
 import { useHistory } from "react-router-dom";
 import { buildThemeFromPalette, toRGBA } from "../../core/podcastPalette";
+import platform from "../../platform";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 const prod = DEBUG ? '' : ''
@@ -174,7 +175,7 @@ function PodcastHeader(props) {
                           onClick={share(
                             "Phonograph",
                             state.title,
-                            `${document.location.origin}/podcast/${makeMeAHash(state.domain)}`
+                            platform.resolveShareUrl(`/podcast/${makeMeAHash(state.domain)}`)
                           )}
                         >
                           <ShareIcon />

--- a/src/podcast/Settings.tsx
+++ b/src/podcast/Settings.tsx
@@ -35,7 +35,7 @@ import UploadFileIcon from "@mui/icons-material/UploadFile";
 import DownloadIcon from "@mui/icons-material/Download";
 
 import { initializeLibrary } from "../engine";
-import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
+import { exportOpmlWithNativeDialog, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
 import { buildOpml, parseOpml } from "./opml";
 import { importFeeds } from "./opmlImporter";
 import { DOWNLOADVIEW } from "../constants";
@@ -228,18 +228,23 @@ const Settings: React.FC = () => {
   const openFilePicker = async () => {
     if (isImporting) return;
 
-    if (hasNativeOpmlDialogs()) {
-      try {
-        const selected = await importOpmlFromNativeDialog();
-        if (!selected) return;
+    try {
+      const selected = await importOpmlFromNativeDialog();
+
+      if (selected.status === "selected") {
         await importOpmlText(selected.text);
-      } catch (err: any) {
-        setNotice({
-          open: true,
-          message: err?.message || intl.formatMessage({ id: "settings.importFailed", defaultMessage: "Failed to import OPML." }),
-          severity: "error",
-        });
+        return;
       }
+
+      if (selected.status === "cancelled") {
+        return;
+      }
+    } catch (err: any) {
+      setNotice({
+        open: true,
+        message: err?.message || intl.formatMessage({ id: "settings.importFailed", defaultMessage: "Failed to import OPML." }),
+        severity: "error",
+      });
       return;
     }
 

--- a/src/serviceworker/worker.ts
+++ b/src/serviceworker/worker.ts
@@ -2,14 +2,44 @@ import PodcastEngine from "podcastsuite";
 
 const DEBUG = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
+const DEFAULT_DESKTOP_API_ORIGIN = "https://phonograph.app";
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const withLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const resolveDesktopBackendOrigin = () => {
+  const configuredOrigin = import.meta.env.VITE_DESKTOP_API_ORIGIN;
+  if (configuredOrigin && configuredOrigin.trim()) {
+    return trimTrailingSlash(configuredOrigin.trim());
+  }
+
+  return DEFAULT_DESKTOP_API_ORIGIN;
+};
+
+const resolveBackendUrl = (path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  const normalizedPath = withLeadingSlash(path);
+  if (location.protocol === "tauri:") {
+    return `${resolveDesktopBackendOrigin()}${normalizedPath}`;
+  }
+
+  return `//${location.host}${normalizedPath}`;
+};
+
 const proxy = DEBUG
   ? {
-      "https:": `//${location.host}/rss-full/?term=https://`,
-      "http:": `//${location.host}/rss-full/?term=http://`,
+      "https:": resolveBackendUrl("/rss-full/?term=https://"),
+      "http:": resolveBackendUrl("/rss-full/?term=http://"),
     }
   : {
-      "https:": `//${location.host}/rss-full/https://`,
-      "http:": `//${location.host}/rss-full/http://`,
+      "https:": resolveBackendUrl("/rss-full/https://"),
+      "http:": resolveBackendUrl("/rss-full/http://"),
     };
 
 const getPodcastEngine = (shouldInit = false) =>

--- a/src/types/vite-env.d.ts
+++ b/src/types/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION?: string;
   readonly VITE_COMMIT_REF?: string;
   readonly VITE_DEPLOY_ID?: string;
+  readonly VITE_DESKTOP_API_ORIGIN?: string;
+  readonly VITE_PUBLIC_WEB_ORIGIN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Harden platform URL resolution so Tauri routes backend and share links through configurable web origins.
- Add desktop version-sync and signing validation automation across desktop scripts and release bump workflows.
- Enable native OPML import/export with Tauri dialog/fs plugins and scoped filesystem permissions.

## Issue Context
Desktop platform hardening pass to make Tauri builds production-ready and keep runtime parity with web routing flows.

## Validation
- `yarn vitest run src/platform/opmlDialogs.test.ts src/platform/index.test.ts src/platform/tauri.test.ts src/platform/web.test.ts`
- `yarn test`
- `yarn typecheck`
- `yarn lint:errors`
- `yarn desktop:sync-version`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `yarn build`

## Rollout Notes
- Desktop release jobs now rely on the new signing env validation script and synced Tauri manifest/Cargo versions.
- Native OPML dialogs are automatically used on Tauri runtime; web fallback file picker remains unchanged.
- Optional desktop env vars are documented in README: `VITE_DESKTOP_API_ORIGIN`, `VITE_PUBLIC_WEB_ORIGIN`.
