### PR TITLE
feat(desktop): harden tauri runtime integration

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -34,12 +34,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Build macOS desktop bundles
         shell: bash
         run: |
           set -euo pipefail
-          yarn desktop:build -- --bundles app,dmg
+          yarn desktop:build -- --target aarch64-apple-darwin,x86_64-apple-darwin --bundles app,dmg
 
       - name: Prepare stable release asset names
         shell: bash
@@ -47,8 +49,8 @@ jobs:
           set -euo pipefail
           mkdir -p release-assets
 
-          arm_dmg="$(find src-tauri/target/release/bundle -type f -name '*aarch64*.dmg' | head -n 1)"
-          intel_dmg="$(find src-tauri/target/release/bundle -type f -name '*x64*.dmg' | head -n 1)"
+          arm_dmg="$(find src-tauri/target/release/bundle -type f \( -name '*aarch64*.dmg' -o -name '*arm64*.dmg' \) | head -n 1)"
+          intel_dmg="$(find src-tauri/target/release/bundle -type f \( -name '*x64*.dmg' -o -name '*x86_64*.dmg' \) | head -n 1)"
 
           if [[ -z "$arm_dmg" || -z "$intel_dmg" ]]; then
             echo "Expected both arm64 and x64 macOS DMG artifacts, but at least one is missing."

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -171,8 +171,16 @@ jobs:
               cp src-tauri/target/release/phonograph desktop-artifacts/
             fi
 
+            if [[ -f src-tauri/target/release/phonograph_desktop ]]; then
+              cp src-tauri/target/release/phonograph_desktop desktop-artifacts/
+            fi
+
             if [[ -f src-tauri/target/release/phonograph.exe ]]; then
               cp src-tauri/target/release/phonograph.exe desktop-artifacts/
+            fi
+
+            if [[ -f src-tauri/target/release/phonograph_desktop.exe ]]; then
+              cp src-tauri/target/release/phonograph_desktop.exe desktop-artifacts/
             fi
 
             {

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Build desktop bundles:
 yarn desktop:build
 ```
 
+Desktop scripts automatically sync the Tauri app version to `package.json` before launching or packaging.
+
 ### Desktop release + download links
 
 - Pushing a semver tag (for example `v1.3.24`) triggers `.github/workflows/desktop-release-macos.yml`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "react-intl": "^8.1.3",
     "react-router": "5.1.2",
     "react-router-dom": "^5.1.2",
+    "@tauri-apps/plugin-dialog": "^2.0.0",
+    "@tauri-apps/plugin-fs": "^2.0.0",
     "smallfetch": "^1.0.8",
     "xml2js": "^0.4.22",
     "zustand": "^5.0.3"
@@ -36,8 +38,9 @@
   ],
   "scripts": {
     "start": "vite",
-    "desktop:dev": "tauri dev",
-    "desktop:build": "tauri build",
+    "desktop:sync-version": "node scripts/sync-tauri-version.mjs",
+    "desktop:dev": "yarn desktop:sync-version && tauri dev",
+    "desktop:build": "yarn desktop:sync-version && tauri build",
     "build": "yarn getter && vite build && yarn SEO && yarn sw && yarn docs:manuals:build && yarn lambda:build",
     "serve": "vite preview",
     "docs:manuals:dev": "vitepress dev manuals",

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -1,1 +1,2 @@
 /target
+/gen

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2298,6 +2298,8 @@ version = "0.1.0"
 dependencies = [
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
 ]
 
 [[package]]
@@ -2670,6 +2672,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3372,6 +3398,63 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,6 +10,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,16 @@
   "identifier": "default",
   "description": "Default capabilities for the main desktop window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "dialog:default",
+    {
+      "identifier": "fs:allow-read-text-file",
+      "allow": [{ "path": "$HOME/**" }]
+    },
+    {
+      "identifier": "fs:allow-write-text-file",
+      "allow": [{ "path": "$HOME/**" }]
+    }
+  ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
 
 fn main() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_fs::init())
     .run(tauri::generate_context!())
     .expect("error while running phonograph desktop shell");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phonograph",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "identifier": "app.phonograph.desktop",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -21,7 +21,7 @@
     ]
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
     "icon": [
       "../public/android-chrome-512x512.png",

--- a/src/platform/opmlDialogs.test.ts
+++ b/src/platform/opmlDialogs.test.ts
@@ -1,5 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "./opmlDialogs";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+}));
+
+import { open, save } from "@tauri-apps/plugin-dialog";
+import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { exportOpmlWithNativeDialog, importOpmlFromNativeDialog } from "./opmlDialogs";
 
 const setWindow = (value: any) => {
   Object.defineProperty(globalThis, "window", {
@@ -11,31 +24,27 @@ const setWindow = (value: any) => {
 
 afterEach(() => {
   setWindow(undefined);
+  vi.clearAllMocks();
 });
 
 describe("opmlDialogs", () => {
-  it("reports unsupported when native APIs are absent", async () => {
+  it("reports unsupported when tauri runtime is absent", async () => {
     setWindow(undefined);
 
-    expect(hasNativeOpmlDialogs()).toBe(false);
-    await expect(importOpmlFromNativeDialog()).resolves.toBeNull();
+    await expect(importOpmlFromNativeDialog()).resolves.toEqual({ status: "unsupported" });
     await expect(exportOpmlWithNativeDialog("<opml />", "subs.opml")).resolves.toBe("unsupported");
   });
 
   it("imports OPML text using native open/read APIs", async () => {
-    const open = vi.fn().mockResolvedValue("/Users/alnavarro/Downloads/subscriptions.opml");
-    const readTextFile = vi.fn().mockResolvedValue("<opml>hello</opml>");
+    setWindow({ __TAURI_INTERNALS__: {} });
 
-    setWindow({
-      __TAURI__: {
-        dialog: { open, save: vi.fn() },
-        fs: { readTextFile, writeTextFile: vi.fn() },
-      },
-    });
+    vi.mocked(open).mockResolvedValue("/Users/alnavarro/Downloads/subscriptions.opml");
+    vi.mocked(readTextFile).mockResolvedValue("<opml>hello</opml>");
 
     const result = await importOpmlFromNativeDialog();
 
     expect(result).toEqual({
+      status: "selected",
       text: "<opml>hello</opml>",
       fileName: "subscriptions.opml",
     });
@@ -44,15 +53,10 @@ describe("opmlDialogs", () => {
   });
 
   it("exports OPML text with native save/write APIs", async () => {
-    const save = vi.fn().mockResolvedValue("/Users/alnavarro/Documents/subs.opml");
-    const writeTextFile = vi.fn().mockResolvedValue(undefined);
+    setWindow({ __TAURI_INTERNALS__: {} });
 
-    setWindow({
-      __TAURI__: {
-        dialog: { open: vi.fn(), save },
-        fs: { readTextFile: vi.fn(), writeTextFile },
-      },
-    });
+    vi.mocked(save).mockResolvedValue("/Users/alnavarro/Documents/subs.opml");
+    vi.mocked(writeTextFile).mockResolvedValue(undefined);
 
     const status = await exportOpmlWithNativeDialog("<opml>content</opml>", "subs.opml");
 
@@ -61,15 +65,13 @@ describe("opmlDialogs", () => {
     expect(writeTextFile).toHaveBeenCalledWith("/Users/alnavarro/Documents/subs.opml", "<opml>content</opml>");
   });
 
-  it("returns cancelled when native save dialog is dismissed", async () => {
-    setWindow({
-      __TAURI__: {
-        dialog: { open: vi.fn(), save: vi.fn().mockResolvedValue(null) },
-        fs: { readTextFile: vi.fn(), writeTextFile: vi.fn() },
-      },
-    });
+  it("returns cancelled when native dialogs are dismissed", async () => {
+    setWindow({ __TAURI_INTERNALS__: {} });
 
+    vi.mocked(open).mockResolvedValue(null);
+    vi.mocked(save).mockResolvedValue(null);
+
+    await expect(importOpmlFromNativeDialog()).resolves.toEqual({ status: "cancelled" });
     await expect(exportOpmlWithNativeDialog("<opml>content</opml>", "subs.opml")).resolves.toBe("cancelled");
   });
 });
-

--- a/src/platform/opmlDialogs.ts
+++ b/src/platform/opmlDialogs.ts
@@ -1,108 +1,41 @@
+import { open, save } from "@tauri-apps/plugin-dialog";
+import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+
 interface TauriDialogFilter {
   name: string;
   extensions: string[];
 }
 
-interface TauriDialogApi {
-  open: (options?: {
-    multiple?: boolean;
-    directory?: boolean;
-    filters?: TauriDialogFilter[];
-    defaultPath?: string;
-    title?: string;
-  }) => Promise<string | string[] | null>;
-  save: (options?: {
-    filters?: TauriDialogFilter[];
-    defaultPath?: string;
-    title?: string;
-  }) => Promise<string | null>;
-}
-
-interface TauriFsApi {
-  readTextFile?: (path: string) => Promise<string>;
-  writeTextFile?: ((path: string, contents: string) => Promise<void>) | ((args: { path: string; contents: string }) => Promise<void>);
-  writeFile?: (args: { path: string; contents: string | number[] | Uint8Array }) => Promise<void>;
-}
+type TauriFilePath = string | URL;
 
 const OPML_DIALOG_FILTERS: TauriDialogFilter[] = [{
   name: "OPML/XML",
   extensions: ["opml", "xml"],
 }];
 
-const getWindowAny = () => {
-  if (typeof window === "undefined") return null;
-  return window as unknown as Record<string, any>;
-};
+const isTauriRuntime = () =>
+  typeof window !== "undefined" && typeof window.__TAURI_INTERNALS__ !== "undefined";
 
-const getTauriDialogApi = (): TauriDialogApi | null => {
-  const win = getWindowAny();
-  if (!win) return null;
+const pathToString = (path: TauriFilePath) =>
+  typeof path === "string" ? path : decodeURIComponent(path.pathname);
 
-  const tauriDialog = win.__TAURI__?.dialog;
-  if (tauriDialog?.open && tauriDialog?.save) {
-    return tauriDialog as TauriDialogApi;
-  }
-
-  const internalsDialog = win.__TAURI_INTERNALS__?.plugins?.dialog;
-  if (internalsDialog?.open && internalsDialog?.save) {
-    return internalsDialog as TauriDialogApi;
-  }
-
-  return null;
-};
-
-const getTauriFsApi = (): TauriFsApi | null => {
-  const win = getWindowAny();
-  if (!win) return null;
-
-  const tauriFs = win.__TAURI__?.fs;
-  if (tauriFs?.readTextFile && (tauriFs?.writeTextFile || tauriFs?.writeFile)) {
-    return tauriFs as TauriFsApi;
-  }
-
-  const internalsFs = win.__TAURI_INTERNALS__?.plugins?.fs;
-  if (internalsFs?.readTextFile && (internalsFs?.writeTextFile || internalsFs?.writeFile)) {
-    return internalsFs as TauriFsApi;
-  }
-
-  return null;
-};
-
-const getFilenameFromPath = (path: string) => {
-  const chunks = path.split(/[\\/]/).filter(Boolean);
+const getFilenameFromPath = (path: TauriFilePath) => {
+  const normalizedPath = pathToString(path);
+  const chunks = normalizedPath.split(/[\\/]/).filter(Boolean);
   return chunks[chunks.length - 1] || "subscriptions.opml";
 };
 
-const writeTextFile = async (fsApi: TauriFsApi, path: string, contents: string) => {
-  if (fsApi.writeTextFile) {
-    try {
-      await (fsApi.writeTextFile as (path: string, contents: string) => Promise<void>)(path, contents);
-      return;
-    } catch (_error) {
-      await (fsApi.writeTextFile as (args: { path: string; contents: string }) => Promise<void>)({ path, contents });
-      return;
-    }
+export type NativeOpmlImportResult =
+  | { status: "selected"; text: string; fileName: string }
+  | { status: "cancelled" }
+  | { status: "unsupported" };
+
+export const importOpmlFromNativeDialog = async (): Promise<NativeOpmlImportResult> => {
+  if (!isTauriRuntime()) {
+    return { status: "unsupported" };
   }
 
-  if (fsApi.writeFile) {
-    await fsApi.writeFile({ path, contents });
-    return;
-  }
-
-  throw new Error("Native file-write API is unavailable.");
-};
-
-export const hasNativeOpmlDialogs = () => Boolean(getTauriDialogApi() && getTauriFsApi());
-
-export const importOpmlFromNativeDialog = async (): Promise<{ text: string; fileName: string } | null> => {
-  const dialogApi = getTauriDialogApi();
-  const fsApi = getTauriFsApi();
-
-  if (!dialogApi || !fsApi?.readTextFile) {
-    return null;
-  }
-
-  const selectedPath = await dialogApi.open({
+  const selectedPath = await open({
     title: "Import OPML",
     directory: false,
     multiple: false,
@@ -110,12 +43,13 @@ export const importOpmlFromNativeDialog = async (): Promise<{ text: string; file
   });
 
   if (!selectedPath || Array.isArray(selectedPath)) {
-    return null;
+    return { status: "cancelled" };
   }
 
-  const text = await fsApi.readTextFile(selectedPath);
+  const text = await readTextFile(selectedPath);
 
   return {
+    status: "selected",
     text,
     fileName: getFilenameFromPath(selectedPath),
   };
@@ -127,14 +61,11 @@ export const exportOpmlWithNativeDialog = async (
   opmlContents: string,
   suggestedFileName: string
 ): Promise<NativeOpmlExportStatus> => {
-  const dialogApi = getTauriDialogApi();
-  const fsApi = getTauriFsApi();
-
-  if (!dialogApi || !fsApi) {
+  if (!isTauriRuntime()) {
     return "unsupported";
   }
 
-  const selectedPath = await dialogApi.save({
+  const selectedPath = await save({
     title: "Export OPML",
     defaultPath: suggestedFileName,
     filters: OPML_DIALOG_FILTERS,
@@ -144,7 +75,6 @@ export const exportOpmlWithNativeDialog = async (
     return "cancelled";
   }
 
-  await writeTextFile(fsApi, selectedPath, opmlContents);
+  await writeTextFile(selectedPath, opmlContents);
   return "saved";
 };
-

--- a/src/podcast/Settings.tsx
+++ b/src/podcast/Settings.tsx
@@ -35,7 +35,7 @@ import UploadFileIcon from "@mui/icons-material/UploadFile";
 import DownloadIcon from "@mui/icons-material/Download";
 
 import { initializeLibrary } from "../engine";
-import { exportOpmlWithNativeDialog, hasNativeOpmlDialogs, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
+import { exportOpmlWithNativeDialog, importOpmlFromNativeDialog } from "../platform/opmlDialogs";
 import { buildOpml, parseOpml } from "./opml";
 import { importFeeds } from "./opmlImporter";
 import { DOWNLOADVIEW } from "../constants";
@@ -228,18 +228,22 @@ const Settings: React.FC = () => {
   const openFilePicker = async () => {
     if (isImporting) return;
 
-    if (hasNativeOpmlDialogs()) {
-      try {
-        const selected = await importOpmlFromNativeDialog();
-        if (!selected) return;
+    try {
+      const selected = await importOpmlFromNativeDialog();
+      if (selected.status === "selected") {
         await importOpmlText(selected.text);
-      } catch (err: any) {
-        setNotice({
-          open: true,
-          message: err?.message || intl.formatMessage({ id: "settings.importFailed", defaultMessage: "Failed to import OPML." }),
-          severity: "error",
-        });
+        return;
       }
+
+      if (selected.status === "cancelled") {
+        return;
+      }
+    } catch (err: any) {
+      setNotice({
+        open: true,
+        message: err?.message || intl.formatMessage({ id: "settings.importFailed", defaultMessage: "Failed to import OPML." }),
+        severity: "error",
+      });
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,6 +2893,11 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
+"@tauri-apps/api@^2.8.0":
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-2.10.1.tgz#57c1bae6114ec33d977eb2b50dfefc25fa84fc93"
+  integrity sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==
+
 "@tauri-apps/cli-darwin-arm64@2.10.1":
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz#7abb013926613555559cce1583ab6521e07b997c"
@@ -2964,6 +2969,20 @@
     "@tauri-apps/cli-win32-arm64-msvc" "2.10.1"
     "@tauri-apps/cli-win32-ia32-msvc" "2.10.1"
     "@tauri-apps/cli-win32-x64-msvc" "2.10.1"
+
+"@tauri-apps/plugin-dialog@^2.0.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz#e09bb26ab7008bfc4a1a044a5fb29ac0575f8898"
+  integrity sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==
+  dependencies:
+    "@tauri-apps/api" "^2.8.0"
+
+"@tauri-apps/plugin-fs@^2.0.0":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-fs/-/plugin-fs-2.4.5.tgz#4b32b6de32e2ee735632bff356fab09fcc281b42"
+  integrity sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==
+  dependencies:
+    "@tauri-apps/api" "^2.8.0"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
## Context
Desktop/Tauri support existed but had several production gaps: OPML native dialogs depended on internal globals, desktop scripts could drift from app version metadata, release packaging assumed single-arch defaults, and CI artifact collection missed the actual desktop binary name.

## What changed
- switched native OPML import/export to official Tauri plugins (`@tauri-apps/plugin-dialog`, `@tauri-apps/plugin-fs`) with explicit runtime guards
- registered dialog/fs plugins in `src-tauri` Rust bootstrap and added desktop capability permissions for read/write text file flows
- added `desktop:sync-version` and chained it into `desktop:dev` + `desktop:build` to keep `src-tauri/tauri.conf.json` aligned with `package.json`
- enabled desktop bundling in Tauri config and aligned desktop version to `1.3.24`
- hardened CI/release flows for desktop:
  - cross-target macOS release build (`aarch64` + `x86_64`)
  - resilient DMG filename detection for both naming variants
  - quality-gates artifact collection for `phonograph_desktop` binaries
- ignored generated Tauri schema output (`src-tauri/gen`) to keep worktrees clean
- updated README desktop section with version-sync behavior

## Validation
- `yarn test src/platform/opmlDialogs.test.ts`
- `yarn quality`
- `yarn desktop:build -- --no-bundle`

## Rollout notes
- No runtime flag changes required.
- Native OPML file dialogs now use official Tauri plugin APIs and desktop permissions, improving stability versus internal runtime access.
- macOS release workflow now emits stable Apple Silicon and Intel DMG asset names from explicit dual-arch builds.
