### PR TITLE
feat(theme): add osaka jade theme palette

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -73,6 +73,7 @@
   "settings.themeDracula": "Dracula",
   "settings.themeHighContrast": "High Contrast",
   "settings.themeNord": "Nord",
+  "settings.themeOsakaJade": "Osaka Jade",
   "settings.themePalette": "Theme Palette",
   "settings.themeSelector": "Theme Selector",
   "settings.title": "Settings",

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -73,6 +73,7 @@
   "settings.themeDracula": "Drácula",
   "settings.themeHighContrast": "Alto contraste",
   "settings.themeNord": "Nord",
+  "settings.themeOsakaJade": "Jade de Osaka",
   "settings.themePalette": "Paleta de temas",
   "settings.themeSelector": "Selector de tema",
   "settings.title": "Ajustes",

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -73,6 +73,7 @@
   "settings.themeDracula": "Dracula",
   "settings.themeHighContrast": "Contraste élevé",
   "settings.themeNord": "Nord",
+  "settings.themeOsakaJade": "Jade d'Osaka",
   "settings.themePalette": "Palette de thèmes",
   "settings.themeSelector": "Sélecteur de thème",
   "settings.title": "Paramètres",

--- a/src/i18n/translations/zh.json
+++ b/src/i18n/translations/zh.json
@@ -73,6 +73,7 @@
   "settings.themeDracula": "德古拉",
   "settings.themeHighContrast": "高对比度",
   "settings.themeNord": "Nord",
+  "settings.themeOsakaJade": "大阪翡翠",
   "settings.themePalette": "主题调色板",
   "settings.themeSelector": "主题选择器",
   "settings.title": "设置",

--- a/src/podcast/Settings.tsx
+++ b/src/podcast/Settings.tsx
@@ -319,6 +319,9 @@ const Settings: React.FC = () => {
               <ToggleButton value={"highContrast"}>
                 <FormattedMessage id="settings.themeHighContrast" defaultMessage="High Contrast" />
               </ToggleButton>
+              <ToggleButton value={"osakaJade"}>
+                <FormattedMessage id="settings.themeOsakaJade" defaultMessage="Osaka Jade" />
+              </ToggleButton>
             </ToggleButtonGroup>
           </div>
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,7 +9,7 @@ const base = {
   },
 };
 
-export type ThemeName = "legacy" | "nord" | "dracula" | "highContrast";
+export type ThemeName = "legacy" | "nord" | "dracula" | "highContrast" | "osakaJade";
 
 export const prefersDark = (): boolean =>
   typeof window !== "undefined" &&
@@ -90,6 +90,22 @@ const createAppTheme = (name: ThemeName = "nord", mode: PaletteMode = "light"): 
         secondary: { main: "#ffffff", contrastText: "#000000" },
         background: { default: "#000000", paper: "#000000" },
         text: { primary: "#ffffff" },
+      },
+    },
+    osakaJade: {
+      light: {
+        mode: "light",
+        primary: { main: "#0E7C66", contrastText: "#ffffff" },
+        secondary: { main: "#2FA48D", contrastText: "#ffffff" },
+        background: { default: "#F2FBF9", paper: "#E1F4EF" },
+        text: { primary: "#12332D", secondary: "#2D5D55" },
+      },
+      dark: {
+        mode: "dark",
+        primary: { main: "#34C3A6", contrastText: "#032A23" },
+        secondary: { main: "#9EEBD9", contrastText: "#032A23" },
+        background: { default: "#071A17", paper: "#0E2A25" },
+        text: { primary: "#D8F5EE", secondary: "#A3D8CC" },
       },
     },
   };

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -36,7 +36,7 @@ export interface PlaylistItem {
   [key: string]: unknown;
 }
 
-export type ThemeName = "legacy" | "nord" | "dracula" | "highContrast";
+export type ThemeName = "legacy" | "nord" | "dracula" | "highContrast" | "osakaJade";
 
 export type SupportedLocale = "en" | "es" | "fr" | "zh";
 


### PR DESCRIPTION
Add osakaJade palette definitions for light/dark modes and expose the new option in settings with i18n labels.